### PR TITLE
Proposing DRC performance patches for #17

### DIFF
--- a/rules/klayout/drc/rule_decks/comp.drc
+++ b/rules/klayout/drc/rule_decks/comp.drc
@@ -63,16 +63,16 @@ if FEOL
 
     df_2a.forget
 
-    df_2b = comp.width(100.um + 1.dbu).polygons(0.001).not_inside(mos_cap_mk)
+    df_2b = comp.not_inside(mos_cap_mk).sized(-50.um).sized(50.um)
     # Rule DF.2b_3.3V: Max. COMP width for all cases except those used for capacitors, marked by ‘MOS_CAP_MK’ layer.
     logger.info("Executing rule DF.2b_3.3V")
-    df2b_l1 = comp.not_inside(mos_cap_mk).not_interacting(df_2b).not_interacting(v5_xtor).not_interacting(dualgate)
+    df2b_l1 = df_2b.not_interacting(v5_xtor).not_interacting(dualgate)
     df2b_l1.output("DF.2b_3.3V", "DF.2b_3.3V : Max. COMP width for all cases except those used for capacitors, marked by ‘MOS_CAP_MK’ layer.")
     df2b_l1.forget
 
     # Rule DF.2b_5V: Max. COMP width for all cases except those used for capacitors, marked by ‘MOS_CAP_MK’ layer.
     logger.info("Executing rule DF.2b_5V")
-    df2b_l1 = comp.not_inside(mos_cap_mk).not_interacting(df_2b).overlapping(dualgate)
+    df2b_l1 = df_2b.overlapping(dualgate)
     df2b_l1.output("DF.2b_5V", "DF.2b_5V : Max. COMP width for all cases except those used for capacitors, marked by ‘MOS_CAP_MK’ layer.")
     df2b_l1.forget
 
@@ -324,25 +324,33 @@ if FEOL
 
     comp_butt.forget
 
+    df12_l2 = comp.not_interacting(schottky_diode)
+    df12_l3 = comp.interacting(comp.not(nplus).not(pplus))
     # Rule DF.12_3.3V: COMP not covered by Nplus or Pplus is forbidden (except those COMP under marking).
     logger.info("Executing rule DF.12_3.3V")
-    df12_l1 = comp.not_interacting(schottky_diode).not_inside(nplus.or(pplus)).not_interacting(v5_xtor).not_interacting(dualgate)
+    df12_l1 = df12_l3.not_interacting(v5_xtor).not_interacting(dualgate)
     df12_l1.output("DF.12_3.3V", "DF.12_3.3V : COMP not covered by Nplus or Pplus is forbidden (except those COMP under marking).")
     df12_l1.forget
 
     # Rule DF.12_5V: COMP not covered by Nplus or Pplus is forbidden (except those COMP under marking).
     logger.info("Executing rule DF.12_5V")
-    df12_l1 = comp.not_interacting(schottky_diode).not_inside(nplus.or(pplus)).overlapping(dualgate)
+    df12_l1 = df12_l3.overlapping(dualgate)
     df12_l1.output("DF.12_5V", "DF.12_5V : COMP not covered by Nplus or Pplus is forbidden (except those COMP under marking).")
     df12_l1.forget
 
-    df13_ncomp = ncomp.inside(nwell.covering(ncomp).covering(pcomp))
-    df13_pcomp = pcomp.inside(nwell.covering(ncomp).covering(pcomp))
+    df12_l2.forget
+    df12_l3.forget
+
+    df13_l2 = nwell.covering(ncomp).covering(pcomp)
+    df13_ncomp = ncomp.inside(df13_l2)
+    df13_pcomp = pcomp.inside(df13_l2)
     # Rule DF.13_3.3V: Max distance of Nwell tap (NCOMP inside Nwell) from (PCOMP inside Nwell).
     logger.info("Executing rule DF.13_3.3V")
     df13_l1 = df13_ncomp.not_interacting(df13_pcomp.sized(20.um)).not_interacting(v5_xtor).not_interacting(dualgate)
     df13_l1.output("DF.13_3.3V", "DF.13_3.3V : Max distance of Nwell tap (NCOMP inside Nwell) from (PCOMP inside Nwell).")
     df13_l1.forget
+
+    df13_l2.forget
 
     # Rule DF.13_5V: Max distance of Nwell tap (NCOMP inside Nwell) from (PCOMP inside Nwell).
     logger.info("Executing rule DF.13_5V")

--- a/rules/klayout/drc/rule_decks/contact.drc
+++ b/rules/klayout/drc/rule_decks/contact.drc
@@ -149,7 +149,7 @@ if BEOL
 
     # Rule CO.11: Contact on field oxide is forbidden.
     logger.info("Executing rule CO.11")
-    co11_l1 = contact.not_inside(comp.or(poly2))
+    co11_l1 = contact.not_inside(comp + poly2)
     co11_l1.output("CO.11", "CO.11 : Contact on field oxide is forbidden.")
     co11_l1.forget
 

--- a/rules/klayout/drc/rule_decks/ldnmos.drc
+++ b/rules/klayout/drc/rule_decks/ldnmos.drc
@@ -54,34 +54,41 @@ if FEOL
 
     end #CONNECTIVITY_RULES
 
-    gate_mdn = poly2.and(comp).and(ldmos_xtor).and(dualgate)
+    poly_mdn = poly2.and(ncomp).inside(ldmos_xtor).inside(dualgate)
+    ldnmos = poly_mdn.not(mvsd)
+    ldnmos_edges = ldnmos.edges
+
     # Rule MDN.3a: Min transistor channel length. is 0.6µm
     logger.info("Executing rule MDN.3a")
-    mdn3a_l1 = gate_mdn.width(0.6.um, euclidian).polygons(0.001)
+    mdn3a_l1 = poly_mdn.enclosing(mvsd, 0.6.um, euclidian).polygons(0.001)
     mdn3a_l1.output("MDN.3a", "MDN.3a : Min transistor channel length. : 0.6µm")
     mdn3a_l1.forget
 
     # Rule MDN.3b: Max transistor channel length.
     logger.info("Executing rule MDN.3b")
-    good_mvsd = gate_mdn.width(20.001.um, euclidian).polygons(0.001)
-    mdn3b_l1 = gate_mdn.not(good_mvsd)
-    mdn3b_l1.output("MDN.3b", "MDN.3b : Max transistor channel length: 20 um")
+    mdn3b_l1 = ldnmos_edges.inside_part(ncomp).not(ldnmos.width(20.um + 1.dbu, projection).edges)
+    mdn3b_l1.output("MDN.3b", "MDN.3b : Max transistor channel length.")
     mdn3b_l1.forget
+
+    ldnmos_gateends = ldnmos_edges.outside_part(ncomp)
 
     # Rule MDN.4a: Min transistor channel width. is 4µm
     logger.info("Executing rule MDN.4a")
-    mdn4a_l1  = gate_mdn.width(4.um, euclidian).polygons(0.001)
-    mdn4a_l1.output("MDN.4a", "MDN.4a : Min transistor channel width. : 4 µm")
+    mdn4a_l1 = ldnmos_gateends.and(ldnmos.width(4.um, projection).edges).extended(0, 0, 0.001, 0.001)
+    mdn4a_l1.output("MDN.4a", "MDN.4a : Min transistor channel width. : 4µm")
     mdn4a_l1.forget
 
     # Rule MDN.4b: Max transistor channel width.
     logger.info("Executing rule MDN.4b")
-    good_gate = gate_mdn.width(50.001.um, euclidian).polygons(0.001)
-    mdn4b_l1 = gate_mdn.not(good_gate)
-    mdn4b_l1.output("MDN.4b", "MDN.4b : Max transistor channel width. : 50 um ")
+    mdn4b_l1 = ldnmos_gateends.not(ldnmos.width(50.um + 1.dbu, projection).edges).extended(0, 0, 0.001, 0.001)
+    mdn4b_l1.output("MDN.4b", "MDN.4b : Max transistor channel width.")
     mdn4b_l1.forget
 
-    gate_mdn.forget
+    ldnmos_gateends.forget
+
+    ldnmos_edges.forget
+    ldnmos.forget
+    poly_mdn.forget
 
     pcomp_mdn5a = pcomp.not_interacting(ncomp).inside(ldmos_xtor).inside(dualgate)
     # Rule MDN.5ai: Min PCOMP (Pplus AND COMP) space to LDNMOS Drain MVSD (source and body tap non-butted). PCOMP (Pplus AND COMP) intercept with LDNMOS Drain MVSD is not allowed.

--- a/rules/klayout/drc/rule_decks/ldpmos.drc
+++ b/rules/klayout/drc/rule_decks/ldpmos.drc
@@ -20,28 +20,34 @@ if FEOL
     #-------------------10V LDPMOS-------------------
     #================================================
 
-    mdp_source = (pcomp).interacting(poly2.and(dualgate).and(ldmos_xtor).and(mvpsd)).not(poly2)
-    ldpmos     = poly2.and(pcomp).and(dualgate).not(mvpsd).inside(ldmos_xtor)
+    poly_mdp     = poly2.and(pcomp).inside(ldmos_xtor).inside(dualgate)
+    mdp_source   = pcomp.interacting(poly_mdp.and(mvpsd)).not(poly2)
+    ldpmos       = poly_mdp.not(mvpsd)
+    ldpmos_edges = ldpmos.edges
+
     # Rule MDP.1: Minimum transistor channel length. is 0.6µm
     logger.info("Executing rule MDP.1")
-    mdp1_l1 = poly2.and(comp).inside(ldmos_xtor).inside(dualgate).enclosing(mvpsd, 0.6.um, euclidian).polygons(0.001)
+    mdp1_l1 = poly_mdp.enclosing(mvpsd, 0.6.um, euclidian).polygons(0.001)
     mdp1_l1.output("MDP.1", "MDP.1 : Minimum transistor channel length. : 0.6µm")
     mdp1_l1.forget
 
-    mvpsd_mdp = mvpsd.edges.and(pcomp).and(poly2)
     # Rule MDP.1a: Max transistor channel length.
     logger.info("Executing rule MDP.1a")
-    mdp1a_l1 = poly2.edges.and(pcomp).or(mvpsd_mdp).and(ldmos_xtor).and(dualgate).not(pgate.not(mvpsd).edges.interacting(poly2.edges.and(pcomp).or(mvpsd_mdp)).width(20.001.um).edges)
+    mdp1a_l1 = ldpmos_edges.inside_part(pcomp).not(ldpmos.width(20.um + 1.dbu, projection).edges).extended(0, 0, 0.001, 0.001)
     mdp1a_l1.output("MDP.1a", "MDP.1a : Max transistor channel length.")
     mdp1a_l1.forget
 
-    mvpsd_mdp.forget
+    ldpmos_gateends = ldpmos_edges.outside_part(pcomp)
 
     # Rule MDP.2: Minimum transistor channel width. is 4µm
     logger.info("Executing rule MDP.2")
-    mdp2_l1  = poly2.and(comp).inside(ldmos_xtor).inside(dualgate).edges.not(mvpsd).interacting(mvpsd).width(4.um, euclidian).polygons(0.001)
+    mdp2_l1 = ldpmos_gateends.and(ldpmos.width(4.um, projection).edges).extended(0, 0, 0.001, 0.001)
     mdp2_l1.output("MDP.2", "MDP.2 : Minimum transistor channel width. : 4µm")
     mdp2_l1.forget
+
+    ldpmos_gateends.forget
+
+    ldpmos_edges.forget
 
     mdp3_1 = ldpmos.or(mvpsd).or(mdp_source).not_interacting(ncomp.holes).inside(dualgate).inside(ldmos_xtor)
     mdp3_2 = ncomp.holes.not_interacting(ncomp.interacting(mdp_source)).not_interacting(mvpsd,1,1).inside(dualgate).inside(ldmos_xtor)
@@ -337,6 +343,10 @@ if FEOL
     mdp17c_l1 = dnwell.with_holes.not_covering(ncomp)
     mdp17c_l1.output("MDP.17c", "MDP.17c : DNWELL guard ring shall have NCOMP tab to be connected to highest potential")
     mdp17c_l1.forget
-    
+
+    mdp_source.forget
+    ldpmos.forget
+    poly_mdp.forget
+
 end
 

--- a/rules/klayout/drc/rule_decks/main.drc
+++ b/rules/klayout/drc/rule_decks/main.drc
@@ -502,7 +502,7 @@ count   = metal1_dummy.count()
 logger.info("metal1_dummy has %d polygons" % [count])
 polygons_count  += count
 
-metal1         = metal1_drawn.or(metal1_dummy)
+metal1         = metal1_drawn + metal1_dummy
 
 metal1_label   = get_polygons(34 , 10)
 count   = metal1_label.count()
@@ -536,7 +536,7 @@ if METAL_LEVEL == "2LM"
   logger.info("metal2_dummy has %d polygons" % [count])
   polygons_count  += count
 
-  metal2        = metal2_drawn.or(metal2_drawn)
+  metal2        = metal2_drawn + metal2_drawn
 
   metal2_label  = get_polygons(53 , 10)
   count   = metal2_label.count()
@@ -569,7 +569,7 @@ else
   logger.info("metal2_dummy has %d polygons" % [count])
   polygons_count  += count
 
-  metal2         = metal2_drawn.or(metal2_dummy)
+  metal2         = metal2_drawn + metal2_dummy
 
   metal2_label   = get_polygons(36 , 10)
   count   = metal2_label.count()
@@ -602,7 +602,7 @@ else
     logger.info("metal3_dummy has %d polygons" % [count])
     polygons_count  += count
 
-    metal3        = metal3_drawn.or(metal3_dummy)
+    metal3        = metal3_drawn + metal3_dummy
 
     metal3_label  = get_polygons(53 , 10)
     count   = metal3_label.count()
@@ -634,7 +634,7 @@ else
     logger.info("metal3_dummy has %d polygons" % [count])
     polygons_count  += count
 
-    metal3        = metal3_drawn.or(metal3_dummy)
+    metal3        = metal3_drawn + metal3_dummy
 
     metal3_label  = get_polygons(42 , 10)
     count   = metal3_label.count()
@@ -664,7 +664,7 @@ else
       logger.info("metal4_dummy has %d polygons" % [count])
       polygons_count  += count
 
-      metal4        = metal4_drawn.or(metal4_dummy)
+      metal4        = metal4_drawn + metal4_dummy
       
       metal4_label  = get_polygons(53 , 10)
       count   = metal4_label.count()
@@ -696,7 +696,7 @@ else
       logger.info("metal4_dummy has %d polygons" % [count])
       polygons_count  += count
 
-      metal4        = metal4_drawn.or(metal4_dummy)
+      metal4        = metal4_drawn + metal4_dummy
 
       metal4_label  = get_polygons(46 , 10)
       count   = metal4_label.count()
@@ -729,7 +729,7 @@ else
         logger.info("metal5_dummy has %d polygons" % [count])
         polygons_count  += count
 
-        metal5        = metal5_drawn.or(metal5_dummy)
+        metal5        = metal5_drawn + metal5_dummy
 
         metal5_label  = get_polygons(53 , 10)
         count   = metal5_label.count()
@@ -762,7 +762,7 @@ else
         logger.info("metal5_dummy has %d polygons" % [count])
         polygons_count  += count
 
-        metal5         = metal5_drawn.or(metal5_dummy)
+        metal5         = metal5_drawn + metal5_dummy
 
         metal5_label   = get_polygons(81 , 10)
         count   = metal5_label.count()
@@ -795,7 +795,7 @@ else
         logger.info("metaltop_dummy has %d polygons" % [count])
         polygons_count  += count
 
-        metaltop       = metaltop_drawn.or(metaltop_dummy)
+        metaltop       = metaltop_drawn + metaltop_dummy
 
         metaltop_label = get_polygons(53 , 10)
         count   = metaltop_label.count()

--- a/rules/klayout/drc/rule_decks/main.drc
+++ b/rules/klayout/drc/rule_decks/main.drc
@@ -189,358 +189,366 @@ end # BEOL
 polygons_count = 0
 logger.info("Read in polygons from layers.")
 
-comp           = polygons(22 , 0 ).merged
+def get_polygons(l, d)
+  if $run_mode == "deep"
+    polygons(l, d)
+  else
+    polygons(l, d).merged
+  end
+end
+
+comp           = get_polygons(22 , 0 )
 count = comp.count()
 logger.info("comp has %d polygons" % [count])
 polygons_count += count
 
-dnwell         = polygons(12 , 0 ).merged
+dnwell         = get_polygons(12 , 0 )
 count   = dnwell.count()
 logger.info("dnwell has %d polygons" % [count])
 polygons_count  += count
 
-nwell          = polygons(21 , 0 ).merged
+nwell          = get_polygons(21 , 0 )
 count   = nwell.count()
 logger.info("nwell has %d polygons" % [count])
 polygons_count  += count
 
-lvpwell        = polygons(204, 0 ).merged
+lvpwell        = get_polygons(204, 0 )
 count   = lvpwell.count()
 logger.info("lvpwell has %d polygons" % [count])
 polygons_count  += count
 
-dualgate       = polygons(55 , 0 ).merged
+dualgate       = get_polygons(55 , 0 )
 count   = dualgate.count()
 logger.info("dualgate has %d polygons" % [count])
 polygons_count  += count
 
-poly2          = polygons(30 , 0 ).merged
+poly2          = get_polygons(30 , 0 )
 count   = poly2.count()
 logger.info("poly2 has %d polygons" % [count])
 polygons_count  += count
 
-nplus          = polygons(32 , 0 ).merged
+nplus          = get_polygons(32 , 0 )
 count   = nplus.count()
 logger.info("nplus has %d polygons" % [count])
 polygons_count  += count
 
-pplus          = polygons(31 , 0 ).merged
+pplus          = get_polygons(31 , 0 )
 count   = pplus.count()
 logger.info("pplus has %d polygons" % [count])
 polygons_count  += count
 
-sab            = polygons(49 , 0 ).merged
+sab            = get_polygons(49 , 0 )
 count   = sab.count()
 logger.info("sab has %d polygons" % [count])
 polygons_count  += count
 
-esd            = polygons(24 , 0 ).merged
+esd            = get_polygons(24 , 0 )
 count   = esd.count()
 logger.info("esd has %d polygons" % [count])
 polygons_count  += count
 
-resistor       = polygons(62 , 0 ).merged
+resistor       = get_polygons(62 , 0 )
 count   = resistor.count()
 logger.info("resistor has %d polygons" % [count])
 polygons_count  += count
 
-fhres          = polygons(227, 0 ).merged
+fhres          = get_polygons(227, 0 )
 count   = fhres.count()
 logger.info("fhres has %d polygons" % [count])
 polygons_count  += count
 
-fusetop        = polygons(75 , 0 ).merged
+fusetop        = get_polygons(75 , 0 )
 count   = fusetop.count()
 logger.info("fusetop has %d polygons" % [count])
 polygons_count  += count
 
-fusewindow_d   = polygons(96 , 1 ).merged
+fusewindow_d   = get_polygons(96 , 1 )
 count   = fusewindow_d.count()
 logger.info("fusewindow_d has %d polygons" % [count])
 polygons_count  += count
 
-polyfuse       = polygons(220, 0 ).merged
+polyfuse       = get_polygons(220, 0 )
 count   = polyfuse.count()
 logger.info("polyfuse has %d polygons" % [count])
 polygons_count  += count
 
-mvsd           = polygons(210, 0 ).merged
+mvsd           = get_polygons(210, 0 )
 count   = mvsd.count()
 logger.info("mvsd has %d polygons" % [count])
 polygons_count  += count
 
-mvpsd          = polygons(11 , 39).merged
+mvpsd          = get_polygons(11 , 39)
 count   = mvpsd.count()
 logger.info("mvpsd has %d polygons" % [count])
 polygons_count  += count
 
-nat            = polygons(5  , 0 ).merged
+nat            = get_polygons(5  , 0 )
 count   = nat.count()
 logger.info("nat has %d polygons" % [count])
 polygons_count  += count
 
-comp_dummy     = polygons(22 , 4 ).merged
+comp_dummy     = get_polygons(22 , 4 )
 count   = comp_dummy.count()
 logger.info("comp_dummy has %d polygons" % [count])
 polygons_count  += count
 
-poly2_dummy    = polygons(30 , 4 ).merged
+poly2_dummy    = get_polygons(30 , 4 )
 count   = poly2_dummy.count()
 logger.info("poly2_dummy has %d polygons" % [count])
 polygons_count  += count
 
-schottky_diode = polygons(241, 0 ).merged
+schottky_diode = get_polygons(241, 0 )
 count   = schottky_diode.count()
 logger.info("schottky_diode has %d polygons" % [count])
 polygons_count  += count
 
-zener          = polygons(178, 0 ).merged
+zener          = get_polygons(178, 0 )
 count   = zener.count()
 logger.info("zener has %d polygons" % [count])
 polygons_count  += count
 
-res_mk         = polygons(110, 5 ).merged
+res_mk         = get_polygons(110, 5 )
 count   = res_mk.count()
 logger.info("res_mk has %d polygons" % [count])
 polygons_count  += count
 
-opc_drc        = polygons(124, 5 ).merged
+opc_drc        = get_polygons(124, 5 )
 count   = opc_drc.count()
 logger.info("opc_drc has %d polygons" % [count])
 polygons_count  += count
 
-ndmy           = polygons(111, 5 ).merged
+ndmy           = get_polygons(111, 5 )
 count   = ndmy.count()
 logger.info("ndmy has %d polygons" % [count])
 polygons_count  += count
 
-pmndmy         = polygons(152, 5 ).merged
+pmndmy         = get_polygons(152, 5 )
 count   = pmndmy.count()
 logger.info("pmndmy has %d polygons" % [count])
 polygons_count  += count
 
-v5_xtor        = polygons(112, 1 ).merged
+v5_xtor        = get_polygons(112, 1 )
 count   = v5_xtor.count()
 logger.info("v5_xtor has %d polygons" % [count])
 polygons_count  += count
 
-cap_mk         = polygons(117, 5 ).merged
+cap_mk         = get_polygons(117, 5 )
 count   = cap_mk.count()
 logger.info("cap_mk has %d polygons" % [count])
 polygons_count  += count
 
-mos_cap_mk     = polygons(166, 5 ).merged
+mos_cap_mk     = get_polygons(166, 5 )
 count   = mos_cap_mk.count()
 logger.info("mos_cap_mk has %d polygons" % [count])
 polygons_count  += count
 
-ind_mk         = polygons(151, 5 ).merged
+ind_mk         = get_polygons(151, 5 )
 count   = ind_mk.count()
 logger.info("ind_mk has %d polygons" % [count])
 polygons_count  += count
 
-diode_mk       = polygons(115, 5 ).merged
+diode_mk       = get_polygons(115, 5 )
 count   = diode_mk.count()
 logger.info("diode_mk has %d polygons" % [count])
 polygons_count  += count
 
-drc_bjt        = polygons(127, 5 ).merged
+drc_bjt        = get_polygons(127, 5 )
 count   = drc_bjt.count()
 logger.info("drc_bjt has %d polygons" % [count])
 polygons_count  += count
 
-lvs_bjt        = polygons(118, 5 ).merged
+lvs_bjt        = get_polygons(118, 5 )
 count   = lvs_bjt.count()
 logger.info("lvs_bjt has %d polygons" % [count])
 polygons_count  += count
 
-mim_l_mk       = polygons(117, 10).merged
+mim_l_mk       = get_polygons(117, 10)
 count   = mim_l_mk.count()
 logger.info("mim_l_mk has %d polygons" % [count])
 polygons_count  += count
 
-latchup_mk     = polygons(137, 5 ).merged
+latchup_mk     = get_polygons(137, 5 )
 count   = latchup_mk.count()
 logger.info("latchup_mk has %d polygons" % [count])
 polygons_count  += count
 
-guard_ring_mk  = polygons(167, 5 ).merged
+guard_ring_mk  = get_polygons(167, 5 )
 count   = guard_ring_mk.count()
 logger.info("guard_ring_mk has %d polygons" % [count])
 polygons_count  += count
 
-otp_mk         = polygons(173, 5 ).merged
+otp_mk         = get_polygons(173, 5 )
 count   = otp_mk.count()
 logger.info("otp_mk has %d polygons" % [count])
 polygons_count  += count
 
-mtpmark        = polygons(122, 5 ).merged
+mtpmark        = get_polygons(122, 5 )
 count   = mtpmark.count()
 logger.info("mtpmark has %d polygons" % [count])
 polygons_count  += count
 
-neo_ee_mk      = polygons(88 , 17).merged
+neo_ee_mk      = get_polygons(88 , 17)
 count   = neo_ee_mk.count()
 logger.info("neo_ee_mk has %d polygons" % [count])
 polygons_count  += count
 
-sramcore       = polygons(108, 5 ).merged
+sramcore       = get_polygons(108, 5 )
 count   = sramcore.count()
 logger.info("sramcore has %d polygons" % [count])
 polygons_count  += count
 
-lvs_rf         = polygons(100, 5 ).merged
+lvs_rf         = get_polygons(100, 5 )
 count   = lvs_rf.count()
 logger.info("lvs_rf has %d polygons" % [count])
 polygons_count  += count
 
-lvs_drain      = polygons(100, 7 ).merged
+lvs_drain      = get_polygons(100, 7 )
 count   = lvs_drain.count()
 logger.info("lvs_drain has %d polygons" % [count])
 polygons_count  += count
 
-ind_mk         = polygons(151, 5 ).merged
+ind_mk         = get_polygons(151, 5 )
 count   = ind_mk.count()
 logger.info("ind_mk has %d polygons" % [count])
 polygons_count  += count
 
-hvpolyrs       = polygons(123, 5 ).merged
+hvpolyrs       = get_polygons(123, 5 )
 count   = hvpolyrs.count()
 logger.info("hvpolyrs has %d polygons" % [count])
 polygons_count  += count
 
-lvs_io         = polygons(119, 5 ).merged
+lvs_io         = get_polygons(119, 5 )
 count   = lvs_io.count()
 logger.info("lvs_io has %d polygons" % [count])
 polygons_count  += count
 
-probe_mk       = polygons(13 , 17).merged
+probe_mk       = get_polygons(13 , 17)
 count   = probe_mk.count()
 logger.info("probe_mk has %d polygons" % [count])
 polygons_count  += count
 
-esd_mk         = polygons(24 , 5 ).merged
+esd_mk         = get_polygons(24 , 5 )
 count   = esd_mk.count()
 logger.info("esd_mk has %d polygons" % [count])
 polygons_count  += count
 
-lvs_source     = polygons(100, 8 ).merged
+lvs_source     = get_polygons(100, 8 )
 count   = lvs_source.count()
 logger.info("lvs_source has %d polygons" % [count])
 polygons_count  += count
 
-well_diode_mk  = polygons(153, 51).merged
+well_diode_mk  = get_polygons(153, 51)
 count   = well_diode_mk.count()
 logger.info("well_diode_mk has %d polygons" % [count])
 polygons_count  += count
 
-ldmos_xtor     = polygons(226, 0 ).merged
+ldmos_xtor     = get_polygons(226, 0 )
 count   = ldmos_xtor.count()
 logger.info("ldmos_xtor has %d polygons" % [count])
 polygons_count  += count
 
-plfuse         = polygons(125, 5 ).merged
+plfuse         = get_polygons(125, 5 )
 count   = plfuse.count()
 logger.info("plfuse has %d polygons" % [count])
 polygons_count  += count
 
-efuse_mk       = polygons(80 , 5 ).merged
+efuse_mk       = get_polygons(80 , 5 )
 count   = efuse_mk.count()
 logger.info("efuse_mk has %d polygons" % [count])
 polygons_count  += count
 
-mcell_feol_mk  = polygons(11 , 17).merged
+mcell_feol_mk  = get_polygons(11 , 17)
 count   = mcell_feol_mk.count()
 logger.info("mcell_feol_mk has %d polygons" % [count])
 polygons_count  += count
 
-ymtp_mk        = polygons(86 , 17).merged
+ymtp_mk        = get_polygons(86 , 17)
 count   = ymtp_mk.count()
 logger.info("ymtp_mk has %d polygons" % [count])
 polygons_count  += count
 
-dev_wf_mk      = polygons(128, 17).merged
+dev_wf_mk      = get_polygons(128, 17)
 count   = dev_wf_mk.count()
 logger.info("dev_wf_mk has %d polygons" % [count])
 polygons_count  += count
 
-comp_label     = polygons(22 , 10).merged
+comp_label     = get_polygons(22 , 10)
 count   = comp_label.count()
 logger.info("comp_label has %d polygons" % [count])
 polygons_count  += count
 
-poly2_label    = polygons(30 , 10).merged
+poly2_label    = get_polygons(30 , 10)
 count   = poly2_label.count()
 logger.info("poly2_label has %d polygons" % [count])
 polygons_count  += count
 
-mdiode         = polygons(116, 5 ).merged
+mdiode         = get_polygons(116, 5 )
 count   = mdiode.count()
 logger.info("mdiode has %d polygons" % [count])
 polygons_count  += count
 
-contact        = polygons(33 , 0 ).merged
+contact        = get_polygons(33 , 0 )
 count   = contact.count()
 logger.info("contact has %d polygons" % [count])
 polygons_count  += count
 
-metal1_drawn   = polygons(34 , 0 ).merged
+metal1_drawn   = get_polygons(34 , 0 )
 count   = metal1_drawn.count()
 logger.info("metal1_drawn has %d polygons" % [count])
 polygons_count  += count
 
-metal1_dummy   = polygons(34 , 4 ).merged
+metal1_dummy   = get_polygons(34 , 4 )
 count   = metal1_dummy.count()
 logger.info("metal1_dummy has %d polygons" % [count])
 polygons_count  += count
 
 metal1         = metal1_drawn.or(metal1_dummy)
 
-metal1_label   = polygons(34 , 10).merged
+metal1_label   = get_polygons(34 , 10)
 count   = metal1_label.count()
 logger.info("metal1_label has %d polygons" % [count])
 polygons_count  += count
 
-metal1_slot    = polygons(34 , 3 ).merged
+metal1_slot    = get_polygons(34 , 3 )
 count   = metal1_slot.count()
 logger.info("metal1_slot has %d polygons" % [count])
 polygons_count  += count
 
-metal1_blk     = polygons(34 , 5 ).merged
+metal1_blk     = get_polygons(34 , 5 )
 count   = metal1_blk.count()
 logger.info("metal1_blk has %d polygons" % [count])
 polygons_count  += count
 
-via1           = polygons(35 , 0 ).merged
+via1           = get_polygons(35 , 0 )
 count   = via1.count()
 logger.info("via1 has %d polygons" % [count])
 polygons_count  += count
 
 
 if METAL_LEVEL == "2LM"
-  metal2_drawn  = polygons(53 , 0 ).merged
+  metal2_drawn  = get_polygons(53 , 0 )
   count   = metal2_drawn.count()
   logger.info("metal2_drawn has %d polygons" % [count])
   polygons_count  += count
 
-  metal2_dummy  = polygons(53 , 4 ).merged
+  metal2_dummy  = get_polygons(53 , 4 )
   count   = metal2_dummy.count()
   logger.info("metal2_dummy has %d polygons" % [count])
   polygons_count  += count
 
   metal2        = metal2_drawn.or(metal2_drawn)
 
-  metal2_label  = polygons(53 , 10).merged
+  metal2_label  = get_polygons(53 , 10)
   count   = metal2_label.count()
   logger.info("metal2_label has %d polygons" % [count])
   polygons_count  += count
 
-  metal2_slot   = polygons(53 , 3 ).merged
+  metal2_slot   = get_polygons(53 , 3 )
   count   = metal2_slot.count()
   logger.info("metal2_slot has %d polygons" % [count])
   polygons_count  += count
 
-  metal2_blk    = polygons(53 , 5 ).merged
+  metal2_blk    = get_polygons(53 , 5 )
   count   = metal2_blk.count()
   logger.info("metal2_blk has %d polygons" % [count])
   polygons_count  += count
@@ -551,62 +559,62 @@ if METAL_LEVEL == "2LM"
   topmin1_metal = metal1
   
 else
-  metal2_drawn   = polygons(36 , 0 ).merged
+  metal2_drawn   = get_polygons(36 , 0 )
   count   = metal2_drawn.count()
   logger.info("metal2_drawn has %d polygons" % [count])
   polygons_count  += count
 
-  metal2_dummy   = polygons(36 , 4 ).merged
+  metal2_dummy   = get_polygons(36 , 4 )
   count   = metal2_dummy.count()
   logger.info("metal2_dummy has %d polygons" % [count])
   polygons_count  += count
 
   metal2         = metal2_drawn.or(metal2_dummy)
 
-  metal2_label   = polygons(36 , 10).merged
+  metal2_label   = get_polygons(36 , 10)
   count   = metal2_label.count()
   logger.info("metal2_label has %d polygons" % [count])
   polygons_count  += count
 
-  metal2_slot    = polygons(36 , 3 ).merged
+  metal2_slot    = get_polygons(36 , 3 )
   count   = metal2_slot.count()
   logger.info("metal2_slot has %d polygons" % [count])
   polygons_count  += count
 
-  metal2_blk     = polygons(36 , 5 ).merged
+  metal2_blk     = get_polygons(36 , 5 )
   count   = metal2_blk.count()
   logger.info("metal2_blk has %d polygons" % [count])
   polygons_count  += count
   
-  via2           = polygons(38 , 0 ).merged
+  via2           = get_polygons(38 , 0 )
   count   = via2.count()
   logger.info("via2 has %d polygons" % [count])
   polygons_count  += count
   
   if METAL_LEVEL == "3LM"
-    metal3_drawn  = polygons(53 , 0 ).merged
+    metal3_drawn  = get_polygons(53 , 0 )
     count   = metal3_drawn.count()
     logger.info("metal3_drawn has %d polygons" % [count])
     polygons_count  += count
 
-    metal3_dummy  = polygons(53 , 4 ).merged
+    metal3_dummy  = get_polygons(53 , 4 )
     count   = metal3_dummy.count()
     logger.info("metal3_dummy has %d polygons" % [count])
     polygons_count  += count
 
     metal3        = metal3_drawn.or(metal3_dummy)
 
-    metal3_label  = polygons(53 , 10).merged
+    metal3_label  = get_polygons(53 , 10)
     count   = metal3_label.count()
     logger.info("metal3_label has %d polygons" % [count])
     polygons_count  += count
     
-    metal3_slot   = polygons(53 , 3 ).merged
+    metal3_slot   = get_polygons(53 , 3 )
     count   = metal3_slot.count()
     logger.info("metal3_slot has %d polygons" % [count])
     polygons_count  += count
 
-    metal3_blk    = polygons(53 , 5 ).merged
+    metal3_blk    = get_polygons(53 , 5 )
     count   = metal3_blk.count()
     logger.info("metal3_blk has %d polygons" % [count])
     polygons_count  += count
@@ -616,59 +624,59 @@ else
     top_metal     = metal3
     topmin1_metal = metal2
   else
-    metal3_drawn  = polygons(42 , 0 ).merged
+    metal3_drawn  = get_polygons(42 , 0 )
     count   = metal3_drawn.count()
     logger.info("metal3_drawn has %d polygons" % [count])
     polygons_count  += count
 
-    metal3_dummy  = polygons(42 , 4 ).merged
+    metal3_dummy  = get_polygons(42 , 4 )
     count   = metal3_dummy.count()
     logger.info("metal3_dummy has %d polygons" % [count])
     polygons_count  += count
 
     metal3        = metal3_drawn.or(metal3_dummy)
 
-    metal3_label  = polygons(42 , 10).merged
+    metal3_label  = get_polygons(42 , 10)
     count   = metal3_label.count()
     logger.info("metal3_label has %d polygons" % [count])
     polygons_count  += count
 
-    metal3_slot   = polygons(42 , 3 ).merged
+    metal3_slot   = get_polygons(42 , 3 )
     count   = metal3_slot.count()
     logger.info("metal3_slot has %d polygons" % [count])
     polygons_count  += count
 
-    metal3_blk    = polygons(42 , 5 ).merged
+    metal3_blk    = get_polygons(42 , 5 )
     count   = metal3_blk.count()
     logger.info("metal3_blk has %d polygons" % [count])
     polygons_count  += count
 
-    via3           = polygons(40 , 0 ).merged
+    via3           = get_polygons(40 , 0 )
 
     if METAL_LEVEL == "4LM"
-      metal4_drawn  = polygons(53 , 0 ).merged
+      metal4_drawn  = get_polygons(53 , 0 )
       count   = metal4_drawn.count()
       logger.info("metal4_drawn has %d polygons" % [count])
       polygons_count  += count
 
-      metal4_dummy  = polygons(53 , 4 ).merged
+      metal4_dummy  = get_polygons(53 , 4 )
       count   = metal4_dummy.count()
       logger.info("metal4_dummy has %d polygons" % [count])
       polygons_count  += count
 
       metal4        = metal4_drawn.or(metal4_dummy)
       
-      metal4_label  = polygons(53 , 10).merged
+      metal4_label  = get_polygons(53 , 10)
       count   = metal4_label.count()
       logger.info("metal4_label has %d polygons" % [count])
       polygons_count  += count
       
-      metal4_slot   = polygons(53 , 3 ).merged
+      metal4_slot   = get_polygons(53 , 3 )
       count   = metal4_slot.count()
       logger.info("metal4_slot has %d polygons" % [count])
       polygons_count  += count
 
-      metal4_blk    = polygons(53 , 5 ).merged
+      metal4_blk    = get_polygons(53 , 5 )
       count   = metal4_blk.count()
       logger.info("metal4_blk has %d polygons" % [count])
       polygons_count  += count
@@ -678,62 +686,62 @@ else
       top_metal     = metal4
       topmin1_metal = metal3
     else
-      metal4_drawn  = polygons(46 , 0 ).merged
+      metal4_drawn  = get_polygons(46 , 0 )
       count   = metal4_drawn.count()
       logger.info("metal4_drawn has %d polygons" % [count])
       polygons_count  += count
 
-      metal4_dummy  = polygons(46 , 4 ).merged
+      metal4_dummy  = get_polygons(46 , 4 )
       count   = metal4_dummy.count()
       logger.info("metal4_dummy has %d polygons" % [count])
       polygons_count  += count
 
       metal4        = metal4_drawn.or(metal4_dummy)
 
-      metal4_label  = polygons(46 , 10).merged
+      metal4_label  = get_polygons(46 , 10)
       count   = metal4_label.count()
       logger.info("metal4_label has %d polygons" % [count])
       polygons_count  += count
 
-      metal4_slot   = polygons(46 , 3 ).merged
+      metal4_slot   = get_polygons(46 , 3 )
       count   = metal4_slot.count()
       logger.info("metal4_slot has %d polygons" % [count])
       polygons_count  += count
 
-      metal4_blk    = polygons(46 , 5 ).merged
+      metal4_blk    = get_polygons(46 , 5 )
       count   = metal4_blk.count()
       logger.info("metal4_blk has %d polygons" % [count])
       polygons_count  += count
 
-      via4          = polygons(41 , 0 ).merged
+      via4          = get_polygons(41 , 0 )
       count   = via4.count()
       logger.info("via4 has %d polygons" % [count])
       polygons_count  += count
 
       if METAL_LEVEL == "5LM"
-        metal5_drawn  = polygons(53 , 0 ).merged
+        metal5_drawn  = get_polygons(53 , 0 )
         count   = metal5_drawn.count()
         logger.info("metal5_drawn has %d polygons" % [count])
         polygons_count  += count
 
-        metal5_dummy  = polygons(53 , 4 ).merged
+        metal5_dummy  = get_polygons(53 , 4 )
         count   = metal5_dummy.count()
         logger.info("metal5_dummy has %d polygons" % [count])
         polygons_count  += count
 
         metal5        = metal5_drawn.or(metal5_dummy)
 
-        metal5_label  = polygons(53 , 10).merged
+        metal5_label  = get_polygons(53 , 10)
         count   = metal5_label.count()
         logger.info("metal5_label has %d polygons" % [count])
         polygons_count  += count
       
-        metal5_slot   = polygons(53 , 3 ).merged
+        metal5_slot   = get_polygons(53 , 3 )
         count   = metal5_slot.count()
         logger.info("metal5_slot has %d polygons" % [count])
         polygons_count  += count
 
-        metal5_blk    = polygons(53 , 5 ).merged
+        metal5_blk    = get_polygons(53 , 5 )
         count   = metal5_blk.count()
         logger.info("metal5_blk has %d polygons" % [count])
         polygons_count  += count
@@ -744,62 +752,62 @@ else
         topmin1_metal = metal4
       else 
         ## 6LM
-        metal5_drawn   = polygons(81 , 0 ).merged
+        metal5_drawn   = get_polygons(81 , 0 )
         count   = metal5_drawn.count()
         logger.info("metal5_drawn has %d polygons" % [count])
         polygons_count  += count
 
-        metal5_dummy   = polygons(81 , 4 ).merged
+        metal5_dummy   = get_polygons(81 , 4 )
         count   = metal5_dummy.count()
         logger.info("metal5_dummy has %d polygons" % [count])
         polygons_count  += count
 
         metal5         = metal5_drawn.or(metal5_dummy)
 
-        metal5_label   = polygons(81 , 10).merged
+        metal5_label   = get_polygons(81 , 10)
         count   = metal5_label.count()
         logger.info("metal5_label has %d polygons" % [count])
         polygons_count  += count
 
-        metal5_slot    = polygons(81 , 3 ).merged
+        metal5_slot    = get_polygons(81 , 3 )
         count   = metal5_slot.count()
         logger.info("metal5_slot has %d polygons" % [count])
         polygons_count  += count
 
-        metal5_blk     = polygons(81 , 5 ).merged
+        metal5_blk     = get_polygons(81 , 5 )
         count   = metal5_blk.count()
         logger.info("metal5_blk has %d polygons" % [count])
         polygons_count  += count
 
-        via5           = polygons(82 , 0 ).merged
+        via5           = get_polygons(82 , 0 )
         count   = via5.count()
         logger.info("via5 has %d polygons" % [count])
         polygons_count  += count
 
 
-        metaltop_drawn = polygons(53 , 0 ).merged
+        metaltop_drawn = get_polygons(53 , 0 )
         count   = metaltop_drawn.count()
         logger.info("metaltop_drawn has %d polygons" % [count])
         polygons_count  += count
 
-        metaltop_dummy = polygons(53 , 4 ).merged
+        metaltop_dummy = get_polygons(53 , 4 )
         count   = metaltop_dummy.count()
         logger.info("metaltop_dummy has %d polygons" % [count])
         polygons_count  += count
 
         metaltop       = metaltop_drawn.or(metaltop_dummy)
 
-        metaltop_label = polygons(53 , 10).merged
+        metaltop_label = get_polygons(53 , 10)
         count   = metaltop_label.count()
         logger.info("metaltop_label has %d polygons" % [count])
         polygons_count  += count
 
-        metaltop_slot  = polygons(53 , 3 ).merged
+        metaltop_slot  = get_polygons(53 , 3 )
         count   = metaltop_slot.count()
         logger.info("metaltop_slot has %d polygons" % [count])
         polygons_count  += count
 
-        metalt_blk     = polygons(53 , 5 ).merged
+        metalt_blk     = get_polygons(53 , 5 )
         count   = metalt_blk.count()
         logger.info("metalt_blk has %d polygons" % [count])
         polygons_count  += count
@@ -813,62 +821,62 @@ else
   end
 end
 
-pad            = polygons(37 , 0 ).merged
+pad            = get_polygons(37 , 0 )
 count   = pad.count()
 logger.info("pad has %d polygons" % [count])
 polygons_count  += count
 
-ubmpperi       = polygons(183, 0 ).merged
+ubmpperi       = get_polygons(183, 0 )
 count   = ubmpperi.count()
 logger.info("ubmpperi has %d polygons" % [count])
 polygons_count  += count
 
-ubmparray      = polygons(184, 0 ).merged
+ubmparray      = get_polygons(184, 0 )
 count   = ubmparray.count()
 logger.info("ubmparray has %d polygons" % [count])
 polygons_count  += count
 
-ubmeplate      = polygons(185, 0 ).merged
+ubmeplate      = get_polygons(185, 0 )
 count   = ubmeplate.count()
 logger.info("ubmeplate has %d polygons" % [count])
 polygons_count  += count
 
-metal1_res     = polygons(110, 11).merged
+metal1_res     = get_polygons(110, 11)
 count   = metal1_res.count()
 logger.info("metal1_res has %d polygons" % [count])
 polygons_count  += count
 
-metal2_res     = polygons(110, 12).merged
+metal2_res     = get_polygons(110, 12)
 count   = metal2_res.count()
 logger.info("metal2_res has %d polygons" % [count])
 polygons_count  += count
 
-metal3_res     = polygons(110, 13).merged
+metal3_res     = get_polygons(110, 13)
 count   = metal3_res.count()
 logger.info("metal3_res has %d polygons" % [count])
 polygons_count  += count
 
-metal4_res     = polygons(110, 14).merged
+metal4_res     = get_polygons(110, 14)
 count   = metal4_res.count()
 logger.info("metal4_res has %d polygons" % [count])
 polygons_count  += count
 
-metal5_res     = polygons(110, 15).merged
+metal5_res     = get_polygons(110, 15)
 count   = metal5_res.count()
 logger.info("metal5_res has %d polygons" % [count])
 polygons_count  += count
 
-metal6_res     = polygons(110, 16).merged
+metal6_res     = get_polygons(110, 16)
 count   = metal6_res.count()
 logger.info("metal6_res has %d polygons" % [count])
 polygons_count  += count
 
-pr_bndry       = polygons(0  , 0 ).merged
+pr_bndry       = get_polygons(0  , 0 )
 count   = pr_bndry.count()
 logger.info("pr_bndry has %d polygons" % [count])
 polygons_count  += count
 
-border         = polygons(63 , 0 ).merged
+border         = get_polygons(63 , 0 )
 count   = border.count()
 logger.info("border has %d polygons" % [count])
 polygons_count  += count

--- a/rules/klayout/drc/rule_decks/sab.drc
+++ b/rules/klayout/drc/rule_decks/sab.drc
@@ -121,8 +121,9 @@ if FEOL
     sb15a_l1.output("SB.15a", "SB.15a : Space from unsalicided Poly2 to unrelated Nplus/Pplus. : 0.18µm")
     sb15a_l1.forget
 
-    sb_15b_1 = poly2.interacting(nplus.or(pplus)).and(sab).edges.not(poly2.edges.and(sab)).separation(nplus.or(pplus).edges, 0.32.um, projection).polygons(0.001)
-    sb_15b_2 = poly2.interacting(nplus.or(pplus)).and(sab).separation(nplus.or(pplus), 0.32.um, projection).polygons(0.001)
+    sb_15b_3 = poly2.interacting(nplus + pplus).and(sab)
+    sb_15b_1 = sb_15b_3.edges.not(poly2.edges.and(sab)).separation(nplus.edges + pplus.edges, 0.32.um, projection).polygons(0.001)
+    sb_15b_2 = sb_15b_3.separation(nplus + pplus, 0.32.um, projection).polygons(0.001)
     # Rule SB.15b: Space from unsalicided Poly2 to unrelated Nplus/Pplus along Poly2 line. is 0.32µm
     logger.info("Executing rule SB.15b")
     sb15b_l1 = sb_15b_1.and(sb_15b_2).outside(otp_mk)
@@ -132,6 +133,8 @@ if FEOL
     sb_15b_1.forget
 
     sb_15b_2.forget
+
+    sb_15b_3.forget
 
     # Rule SB.16: SAB layer cannot exist on 3.3V and 5V/6V CMOS transistors' Poly and COMP area of the core circuit (Excluding the transistors used for ESD purpose). It can only exist on CMOS transistors marked by LVS_IO, OTP_MK, ESD_MK layers.
     logger.info("Executing rule SB.16")

--- a/rules/klayout/drc/rule_decks/via1.drc
+++ b/rules/klayout/drc/rule_decks/via1.drc
@@ -85,7 +85,7 @@ if BEOL
 
     # Rule V1.4a: metal-2 overlap of via1.
     logger.info("Executing rule V1.4a")
-    v14a_l1 = metal2.enclosing(via1, 0.01.um, euclidian).polygons(0.001).or(via1.not_inside(metal2).not(metal2))
+    v14a_l1 = via1.enclosed(metal2, 0.01.um, euclidian).polygons(0.001).or(via1.not_inside(metal2).not(metal2))
     v14a_l1.output("V1.4a", "V1.4a : metal-2 overlap of via1.")
     v14a_l1.forget
     

--- a/rules/klayout/drc/rule_decks/via2.drc
+++ b/rules/klayout/drc/rule_decks/via2.drc
@@ -52,7 +52,7 @@ if BEOL
 
         # Rule V2.3b: metal2  overlap of via2.
         logger.info("Executing rule V2.3b")
-        v23b_l1 = metal2.enclosing(via2, 0.01.um, euclidian).polygons(0.001).or(via2.not_inside(metal2).not(metal2))
+        v23b_l1 = via2.enclosed(metal2, 0.01.um, euclidian).polygons(0.001).or(via2.not_inside(metal2).not(metal2))
         v23b_l1.output("V2.3b", "V2.3b : metal2  overlap of via2.")
         v23b_l1.forget
         
@@ -88,7 +88,7 @@ if BEOL
 
         # Rule V2.4a: metal3 overlap of via2.
         logger.info("Executing rule V2.4a")
-        v24a_l1 = metal3.enclosing(via2, 0.01.um, euclidian).polygons(0.001).or(via2.not_inside(metal3).not(metal3))
+        v24a_l1 = via2.enclosed(metal3, 0.01.um, euclidian).polygons(0.001).or(via2.not_inside(metal3).not(metal3))
         v24a_l1.output("V2.4a", "V2.4a : metal3 overlap of via2.")
         v24a_l1.forget
 

--- a/rules/klayout/drc/rule_decks/via3.drc
+++ b/rules/klayout/drc/rule_decks/via3.drc
@@ -51,7 +51,7 @@ if BEOL
 
         # Rule V3.3b: metal3  overlap of via3.
         logger.info("Executing rule V3.3b")
-        v33b_l1 = metal3.enclosing(via3, 0.01.um, euclidian).polygons(0.001).or(via3.not_inside(metal3).not(metal3))
+        v33b_l1 = via3.enclosed(metal3, 0.01.um, euclidian).polygons(0.001).or(via3.not_inside(metal3).not(metal3))
         v33b_l1.output("V3.3b", "V3.3b : metal3  overlap of via3.")
         v33b_l1.forget
 
@@ -87,7 +87,7 @@ if BEOL
 
         # Rule V3.4a: metal4 overlap of via3.
         logger.info("Executing rule V3.4a")
-        v34a_l1 = metal4.enclosing(via3, 0.01.um, euclidian).polygons(0.001).or(via3.not_inside(metal4).not(metal4))
+        v34a_l1 = via3.enclosed(metal4, 0.01.um, euclidian).polygons(0.001).or(via3.not_inside(metal4).not(metal4))
         v34a_l1.output("V3.4a", "V3.4a : metal4 overlap of via3.")
         v34a_l1.forget
 

--- a/rules/klayout/drc/rule_decks/via4.drc
+++ b/rules/klayout/drc/rule_decks/via4.drc
@@ -52,7 +52,7 @@ if BEOL
 
         # Rule V4.3b: metal4  overlap of via4.
         logger.info("Executing rule V4.3b")
-        v43b_l1 = metal4.enclosing(via4, 0.01.um, euclidian).polygons(0.001).or(via4.not_inside(metal4).not(metal4))
+        v43b_l1 = via4.enclosed(metal4, 0.01.um, euclidian).polygons(0.001).or(via4.not_inside(metal4).not(metal4))
         v43b_l1.output("V4.3b", "V4.3b : metal4  overlap of via4.")
         v43b_l1.forget
 
@@ -92,7 +92,7 @@ if BEOL
             v44a_l1.output("V4.4a", "V4.4a : metal5 overlap of via4.")
             v44a_l1.forget
         else
-            v44a_l1 = metal5.enclosing(via4, 0.01.um, euclidian).polygons(0.001).or(via4.not_inside(metal5).not(metal5))
+            v44a_l1 = via4.enclosed(metal5, 0.01.um, euclidian).polygons(0.001).or(via4.not_inside(metal5).not(metal5))
             v44a_l1.output("V4.4a", "V4.4a : metal5 overlap of via4.")
             v44a_l1.forget
         end

--- a/rules/klayout/drc/rule_decks/via4.drc
+++ b/rules/klayout/drc/rule_decks/via4.drc
@@ -92,7 +92,7 @@ if BEOL
             v44a_l1.output("V4.4a", "V4.4a : metal5 overlap of via4.")
             v44a_l1.forget
         else
-            v44a_l1 = via4.enclosed(metal5, 0.01.um, euclidian).polygons(0.001).or(via4.not_inside(metal5).not(metal5))
+            v44a_l1 = metal5.enclosing(via4, 0.01.um, euclidian).polygons(0.001).or(via4.not_inside(metal5).not(metal5))
             v44a_l1.output("V4.4a", "V4.4a : metal5 overlap of via4.")
             v44a_l1.forget
         end

--- a/rules/klayout/drc/rule_decks/via5.drc
+++ b/rules/klayout/drc/rule_decks/via5.drc
@@ -51,7 +51,7 @@ if BEOL
 
         # Rule V5.3b: metal5  overlap of via5.
         logger.info("Executing rule V5.3b")
-        v53b_l1 = metal5.enclosing(via5, 0.01.um, euclidian).polygons(0.001).or(via5.not_inside(metal5).not(metal5))
+        v53b_l1 = via5.enclosed(metal5, 0.01.um, euclidian).polygons(0.001).or(via5.not_inside(metal5).not(metal5))
         v53b_l1.output("V5.3b", "V5.3b : metal5  overlap of via5.")
         v53b_l1.forget
 
@@ -86,7 +86,7 @@ if BEOL
 
         # Rule V5.4a: metaltop overlap of via5.
         logger.info("Executing rule V5.4a")
-        v54a_l1 = metaltop.enclosing(via5, 0.01.um, euclidian).polygons(0.001).or(via5.not_inside(metaltop).not(metaltop))
+        v54a_l1 = via5.enclosed(metaltop, 0.01.um, euclidian).polygons(0.001).or(via5.not_inside(metaltop).not(metaltop))
         v54a_l1.output("V5.4a", "V5.4a : metaltop overlap of via5.")
         v54a_l1.forget
 

--- a/rules/klayout/drc/run_drc.py
+++ b/rules/klayout/drc/run_drc.py
@@ -17,7 +17,7 @@ Run GlobalFoundries 180nm MCU DRC.
 
 Usage:
     run_drc.py (--help| -h)
-    run_drc.py (--path=<file_path>) (--variant=<combined_options>) [--table=<table_name>]... [--mp=<num_cores>] [--run_dir=<run_dir_path>] [--topcell=<topcell_name>] [--thr=<thr>] [--run_mode=<run_mode>] [--no_feol] [--no_beol] [--connectivity] [--density] [--density_only] [--antenna] [--antenna_only] [--no_offgrid]
+    run_drc.py (--path=<file_path>) (--variant=<combined_options>) [--verbose] [--table=<table_name>]... [--mp=<num_cores>] [--run_dir=<run_dir_path>] [--topcell=<topcell_name>] [--thr=<thr>] [--run_mode=<run_mode>] [--no_feol] [--no_beol] [--connectivity] [--density] [--density_only] [--antenna] [--antenna_only] [--no_offgrid]
 
 Options:
     --help -h                           Print this help message.
@@ -34,6 +34,7 @@ Options:
     --run_mode=<run_mode>               Select klayout mode Allowed modes (flat , deep, tiling). [default: flat]
     --no_feol                           Turn off FEOL rules from running.
     --no_beol                           Turn off BEOL rules from running.
+    --verbose                           Verbose mode
     --connectivity                      Turn on connectivity rules.
     --density                           Turn on Density rules.
     --density_only                      Turn on Density rules only.
@@ -252,6 +253,11 @@ def generate_klayout_switches(arguments, layout_path):
         os.cpu_count() * 2 if arguments["--thr"] == None else int(arguments["--thr"])
     )
     switches["thr"] = str(int(thrCount))
+
+    if arguments["--verbose"]:
+        switches["verbose"] = "true"
+    else:
+        switches["verbose"] = "false"
 
     if arguments["--run_mode"] in ["flat", "deep", "tiling"]:
         switches["run_mode"] = arguments["--run_mode"]


### PR DESCRIPTION
Fixes #17

I'm trying once again to propose some fundamental changes to improve performance in deep mode ;)

Specifically:

* An alternative implementation of the LDMOS checks
* Skip merging of input layers in deep mode
* Some minor patches - e.g. turning `metal.enclosing(via, ...)` into `via.enclosed(metal, ...)`.

With these changes, the test case from #17 executes in 2700s (4 threads, deep mode, no connectivity checks) at around 3.5G peak memory. Some DRC issues are flagged which IMHO are real issues. Specifically, V4.4a fails which is because the layout is not made for 5LM (metal5 is on layer 81 which it should be on 53 for top metal). I don't see how to enable 6LM (option D?), so V4.4a is rightfully complaining about missing top metal for via4.

It's up to you whether to accept this patch or not. But to state that clearly: without optimization - specifically the ones proposed here - a reasonable DRC runtime cannot be achieved. Flat mode rules out for this complexity, deep mode can be very fast but also very slow without optimization. There is no "magic KLayout patch" that makes an any DRC deck run fast. There are surely some problems that can be mitigated on KLayout side, but there is no universal coding scheme for complex DRC rules and every tool works differently. So you need to be willing to optimize for a specific tool. For some more details see my comments on #17.

- [ ] Tests pass
- [ ] Appropriate changes to README are included in PR