### PR TITLE
fix klayout drc rules for interactive usage

### DIFF
--- a/rules/klayout/drc/rule_decks/antenna.drc
+++ b/rules/klayout/drc/rule_decks/antenna.drc
@@ -47,7 +47,7 @@ if $report
     logger.info("GF180MCU Klayout antenna checks DRC runset output at: %s" % [$report])
     report("GF180 ANTENNA DRC runset", $report)
 else
-    logger.info("GF180MCU Klayout antenna checks DRC runset output at default location." % [File.join(File.dirname(RBA::CellView::active.filename), "gf180mcu_antenna.lyrdb").path])
+    logger.info("GF180MCU Klayout antenna checks DRC runset output at default location." % [File.join(File.dirname(RBA::CellView::active.filename), "gf180mcu_antenna.lyrdb")])
     report("GF180 DRC runset", File.join(File.dirname(RBA::CellView::active.filename), "gf180mcu_antenna.lyrdb"))
 end
 

--- a/rules/klayout/drc/rule_decks/antenna.drc
+++ b/rules/klayout/drc/rule_decks/antenna.drc
@@ -162,7 +162,7 @@ end #METAL_TOP
 if $metal_level
     METAL_LEVEL = $metal_level
 else
-    METAL_LEVEL = "6LM"
+    METAL_LEVEL = "5LM"
 end
 
 logger.info("METAL_STACK Selected is %s" % [METAL_LEVEL])

--- a/rules/klayout/drc/rule_decks/density.drc
+++ b/rules/klayout/drc/rule_decks/density.drc
@@ -47,7 +47,7 @@ if $report
     logger.info("GF180MCU Klayout density checks DRC runset output at: %s" % [$report])
     report("GF180 DENSITY DRC runset", $report)
 else
-    logger.info("GF180MCU Klayout density checks DRC runset output at default location." % [File.join(File.dirname(RBA::CellView::active.filename), "gf180mcu_density.lyrdb").path])
+    logger.info("GF180MCU Klayout density checks DRC runset output at default location." % [File.join(File.dirname(RBA::CellView::active.filename), "gf180mcu_density.lyrdb")])
     report("GF180 DRC runset", File.join(File.dirname(RBA::CellView::active.filename), "gf180mcu_density.lyrdb"))
 end
 


### PR DESCRIPTION
- fix path usage in logging message
- fix default stack (`5LM`)

This only triggered when using the script interactively in klayout.

Related https://github.com/google/globalfoundries-pdk-libs-gf180mcu_fd_pv/issues/39