### PR TITLE
rules/klayout/lvs: try multiple netlist formats

### DIFF
--- a/rules/klayout/lvs/gf180mcu.lvs
+++ b/rules/klayout/lvs/gf180mcu.lvs
@@ -255,13 +255,15 @@ if $schematic
   schematic($schematic, reader)
   logger.info("Netlist file: #{$schematic}")
 else
-  begin  
-    schematic("#{source.cell_name}.cdl", reader)
-    logger.info("Netlist file: #{source.cell_name}.cdl")
-  rescue 
-    puts "No schematic loaded , please add your netlist file"
-    logger.error("No schematic loaded , please add your netlist file")
-  end 
+  exts = ["ngspice", "spice", "cdl"]
+  candidates = exts.map{|ext| "#{source.cell_name}.#{ext}"}  
+  netlists = candidates.select{|f| File.exist?(f)}
+  if netlists.empty?
+    error("Netlist not found, tried: #{candidates}")
+  else
+    schematic(netlists[0], reader)
+    logger.info("Netlist file: #{netlists[0]}")
+  end
 end
 
 class BResistor < RBA::DeviceClassResistorWithBulk

--- a/rules/klayout/lvs/gf180mcu.lvs
+++ b/rules/klayout/lvs/gf180mcu.lvs
@@ -255,7 +255,7 @@ if $schematic
   schematic($schematic, reader)
   logger.info("Netlist file: #{$schematic}")
 else
-  exts = ["ngspice", "spice", "cdl"]
+  exts = ["spice", "cdl"]
   candidates = exts.map{|ext| "#{source.cell_name}.#{ext}"}  
   netlists = candidates.select{|f| File.exist?(f)}
   if netlists.empty?


### PR DESCRIPTION
Related: https://github.com/google/globalfoundries-pdk-libs-gf180mcu_fd_pr/pull/99 https://github.com/google/globalfoundries-pdk-libs-gf180mcu_fd_pr/issues/101 https://github.com/google/globalfoundries-pdk-libs-gf180mcu_fd_pv/issues/39 https://github.com/RTimothyEdwards/open_pdks/issues/346

This allow to discover LVS netlists generated by xschem with their default extension (`.spice`).
