### PR TITLE
Alowing the use of GDSFactory programmatic layout design

### DIFF
--- a/cells/klayout/pymacros/cells/cap_mim.py
+++ b/cells/klayout/pymacros/cells/cap_mim.py
@@ -20,6 +20,8 @@ import pya
 import os
 from .draw_cap_mim import draw_cap_mim
 
+from .pcell_utilities import gf_to_pya
+
 mim_min_l = 5
 mim_min_w = 5
 mim_cap_area: float = (100 * 100)
@@ -98,7 +100,8 @@ class cap_mim(pya.PCellDeclarationHelper):
 
     def produce_impl(self):
 
-        np_instance = draw_cap_mim(
+        instance = draw_cap_mim(
+            "mim_cap_dev",
             self.layout,
             lc=self.lc,
             wc=self.wc,
@@ -108,8 +111,12 @@ class cap_mim(pya.PCellDeclarationHelper):
             top_lbl=self.top_lbl,
             bot_lbl=self.bot_lbl,
         )
+
+        # creating layout and cell in klayout
+        instance = gf_to_pya(self.layout, instance, "mim_cap")
+        
         write_cells = pya.CellInstArray(
-            np_instance.cell_index(),
+            instance.cell_index(),
             pya.Trans(pya.Point(0, 0)),
             pya.Vector(0, 0),
             pya.Vector(0, 0),

--- a/cells/klayout/pymacros/cells/cap_mos.py
+++ b/cells/klayout/pymacros/cells/cap_mos.py
@@ -19,6 +19,8 @@
 import pya
 from .draw_cap_mos import draw_cap_mos
 
+from .pcell_utilities import gf_to_pya
+
 cap_nmos_w = 1
 cap_nmos_l = 1
 
@@ -94,7 +96,8 @@ class cap_nmos(pya.PCellDeclarationHelper):
         return pya.Trans(self.shape.bbox().center())
 
     def produce_impl(self):
-        np_instance = draw_cap_mos(
+        instance = draw_cap_mos(
+            "cap_mos_dev",
             self.layout,
             type="cap_nmos",
             lc=self.lc,
@@ -106,8 +109,12 @@ class cap_nmos(pya.PCellDeclarationHelper):
             g_lbl=self.g_lbl,
             sd_lbl=self.sd_lbl,
         )
+
+        # creating layout and cell in klayout
+        instance = gf_to_pya(self.layout, instance, "cap_mos")
+
         write_cells = pya.CellInstArray(
-            np_instance.cell_index(),
+            instance.cell_index(),
             pya.Trans(pya.Point(0, 0)),
             pya.Vector(0, 0),
             pya.Vector(0, 0),
@@ -179,7 +186,8 @@ class cap_pmos(pya.PCellDeclarationHelper):
         return pya.Trans(self.shape.bbox().center())
 
     def produce_impl(self):
-        np_instance = draw_cap_mos(
+        instance = draw_cap_mos(
+            "cap_mos_dev",
             self.layout,
             type="cap_pmos",
             lc=self.lc,
@@ -191,8 +199,12 @@ class cap_pmos(pya.PCellDeclarationHelper):
             g_lbl=self.g_lbl,
             sd_lbl=self.sd_lbl,
         )
+        
+        # creating layout and cell in klayout
+        instance = gf_to_pya(self.layout, instance, "cap_mos")
+
         write_cells = pya.CellInstArray(
-            np_instance.cell_index(),
+            instance.cell_index(),
             pya.Trans(pya.Point(0, 0)),
             pya.Vector(0, 0),
             pya.Vector(0, 0),
@@ -262,7 +274,8 @@ class cap_nmos_b(pya.PCellDeclarationHelper):
         return pya.Trans(self.shape.bbox().center())
 
     def produce_impl(self):
-        np_instance = draw_cap_mos(
+        instance = draw_cap_mos(
+            "cap_mos_dev",
             self.layout,
             type="cap_nmos_b",
             lc=self.lc,
@@ -274,8 +287,12 @@ class cap_nmos_b(pya.PCellDeclarationHelper):
             g_lbl=self.g_lbl,
             sd_lbl=self.sd_lbl,
         )
+        
+        # creating layout and cell in klayout
+        instance = gf_to_pya(self.layout, instance, "cap_mos")
+
         write_cells = pya.CellInstArray(
-            np_instance.cell_index(),
+            instance.cell_index(),
             pya.Trans(pya.Point(0, 0)),
             pya.Vector(0, 0),
             pya.Vector(0, 0),
@@ -345,7 +362,8 @@ class cap_pmos_b(pya.PCellDeclarationHelper):
         return pya.Trans(self.shape.bbox().center())
 
     def produce_impl(self):
-        np_instance = draw_cap_mos(
+        instance = draw_cap_mos(
+            "cap_mos_dev",
             self.layout,
             type="cap_pmos_b",
             lc=self.lc,
@@ -357,8 +375,12 @@ class cap_pmos_b(pya.PCellDeclarationHelper):
             g_lbl=self.g_lbl,
             sd_lbl=self.sd_lbl,
         )
+        
+        # creating layout and cell in klayout
+        instance = gf_to_pya(self.layout, instance, "cap_mos")
+
         write_cells = pya.CellInstArray(
-            np_instance.cell_index(),
+            instance.cell_index(),
             pya.Trans(pya.Point(0, 0)),
             pya.Vector(0, 0),
             pya.Vector(0, 0),

--- a/cells/klayout/pymacros/cells/diode.py
+++ b/cells/klayout/pymacros/cells/diode.py
@@ -26,6 +26,8 @@ from .draw_diode import (
     draw_sc_diode,
 )
 
+from .pcell_utilities import gf_to_pya
+
 np_l = 0.36
 np_w = 0.36
 
@@ -117,7 +119,8 @@ class diode_nd2ps(pya.PCellDeclarationHelper):
         return pya.Trans(self.shape.bbox().center())
 
     def produce_impl(self):
-        np_instance = draw_diode_nd2ps(
+        instance = draw_diode_nd2ps(
+            "diode_nd2ps_dev",
             self.layout,
             la=self.la,
             wa=self.wa,
@@ -129,8 +132,12 @@ class diode_nd2ps(pya.PCellDeclarationHelper):
             p_lbl=self.p_lbl,
             n_lbl=self.n_lbl,
         )
+        
+        # creating layout and cell in klayout
+        instance = gf_to_pya(self.layout, instance, "diode_nd2ps")
+
         write_cells = pya.CellInstArray(
-            np_instance.cell_index(),
+            instance.cell_index(),
             pya.Trans(pya.Point(0, 0)),
             pya.Vector(0, 0),
             pya.Vector(0, 0),
@@ -207,7 +214,8 @@ class diode_pd2nw(pya.PCellDeclarationHelper):
         return pya.Trans(self.shape.bbox().center())
 
     def produce_impl(self):
-        np_instance = draw_diode_pd2nw(
+        instance = draw_diode_pd2nw(
+            "diode_pd2nw_dev",
             self.layout,
             la=self.la,
             wa=self.wa,
@@ -219,8 +227,12 @@ class diode_pd2nw(pya.PCellDeclarationHelper):
             p_lbl=self.p_lbl,
             n_lbl=self.n_lbl,
         )
+        
+        # creating layout and cell in klayout
+        instance = gf_to_pya(self.layout, instance, "diode_pd2nw")
+
         write_cells = pya.CellInstArray(
-            np_instance.cell_index(),
+            instance.cell_index(),
             pya.Trans(pya.Point(0, 0)),
             pya.Vector(0, 0),
             pya.Vector(0, 0),
@@ -295,7 +307,8 @@ class diode_nw2ps(pya.PCellDeclarationHelper):
         return pya.Trans(self.shape.bbox().center())
 
     def produce_impl(self):
-        nwp_instance = draw_diode_nw2ps(
+        instance = draw_diode_nw2ps(
+            "diode_nw2ps_dev",
             self.layout,
             la=self.la,
             wa=self.wa,
@@ -305,8 +318,12 @@ class diode_nw2ps(pya.PCellDeclarationHelper):
             p_lbl=self.p_lbl,
             n_lbl=self.n_lbl,
         )
+        
+        # creating layout and cell in klayout
+        instance = gf_to_pya(self.layout, instance, "diode_nw2ps")
+
         write_cells = pya.CellInstArray(
-            nwp_instance.cell_index(),
+            instance.cell_index(),
             pya.Trans(pya.Point(0, 0)),
             pya.Vector(0, 0),
             pya.Vector(0, 0),
@@ -384,7 +401,8 @@ class diode_pw2dw(pya.PCellDeclarationHelper):
         return pya.Trans(self.shape.bbox().center())
 
     def produce_impl(self):
-        diode_pw2dw_instance = draw_diode_pw2dw(
+        instance = draw_diode_pw2dw(
+            "diode_pw2dw_dev",
             self.layout,
             la=self.la,
             wa=self.wa,
@@ -395,8 +413,12 @@ class diode_pw2dw(pya.PCellDeclarationHelper):
             p_lbl=self.p_lbl,
             n_lbl=self.n_lbl,
         )
+        
+        # creating layout and cell in klayout
+        instance = gf_to_pya(self.layout, instance, "diode_pw2dw")
+
         write_cells = pya.CellInstArray(
-            diode_pw2dw_instance.cell_index(),
+            instance.cell_index(),
             pya.Trans(pya.Point(0, 0)),
             pya.Vector(0, 0),
             pya.Vector(0, 0),
@@ -471,7 +493,8 @@ class diode_dw2ps(pya.PCellDeclarationHelper):
         return pya.Trans(self.shape.bbox().center())
 
     def produce_impl(self):
-        diode_dw2ps_instance = draw_diode_dw2ps(
+        instance = draw_diode_dw2ps(
+            "diode_dw2ps_dev",
             self.layout,
             la=self.la,
             wa=self.wa,
@@ -482,8 +505,12 @@ class diode_dw2ps(pya.PCellDeclarationHelper):
             p_lbl=self.p_lbl,
             n_lbl=self.n_lbl,
         )
+        
+        # creating layout and cell in klayout
+        instance = gf_to_pya(self.layout, instance, "diode_dw2ps")
+
         write_cells = pya.CellInstArray(
-            diode_dw2ps_instance.cell_index(),
+            instance.cell_index(),
             pya.Trans(pya.Point(0, 0)),
             pya.Vector(0, 0),
             pya.Vector(0, 0),
@@ -554,7 +581,8 @@ class sc_diode(pya.PCellDeclarationHelper):
         return pya.Trans(self.shape.bbox().center())
 
     def produce_impl(self):
-        sc_instance = draw_sc_diode(
+        instance = draw_sc_diode(
+            "sc_diode_dev",
             self.layout,
             la=self.la,
             wa=self.wa,
@@ -565,8 +593,12 @@ class sc_diode(pya.PCellDeclarationHelper):
             p_lbl=self.p_lbl,
             n_lbl=self.n_lbl,
         )
+        
+        # creating layout and cell in klayout
+        instance = gf_to_pya(self.layout, instance, "sc_diode")
+
         write_cells = pya.CellInstArray(
-            sc_instance.cell_index(),
+            instance.cell_index(),
             pya.Trans(pya.Point(0, 0)),
             pya.Vector(0, 0),
             pya.Vector(0, 0),

--- a/cells/klayout/pymacros/cells/draw_cap_mim.py
+++ b/cells/klayout/pymacros/cells/draw_cap_mim.py
@@ -5,6 +5,7 @@ from .layers_def import layer
 import os
 
 
+@gf.cell
 def draw_cap_mim(
     layout,
     mim_option: str = "A",
@@ -14,7 +15,7 @@ def draw_cap_mim(
     lbl: bool = 0,
     top_lbl: str = "",
     bot_lbl: str = "",
-):
+) -> gf.Component:
 
     """
     Retern mim cap
@@ -27,7 +28,7 @@ def draw_cap_mim(
 
     """
 
-    c = gf.Component("mim_cap_dev")
+    c = gf.Component()
 
     # used dimensions and layers
 
@@ -137,8 +138,4 @@ def draw_cap_mim(
     )
     c.add_ref(via)
 
-    c.write_gds("mim_cap_temp.gds")
-    layout.read("mim_cap_temp.gds")
-    os.remove("mim_cap_temp.gds")
-
-    return layout.cell(c.name)
+    return c

--- a/cells/klayout/pymacros/cells/draw_cap_mos.py
+++ b/cells/klayout/pymacros/cells/draw_cap_mos.py
@@ -25,6 +25,8 @@ from .layers_def import layer
 import numpy as np
 import os
 
+from .pcell_utilities import gf_to_pya
+
 
 @gf.cell
 def cap_mos_inst(
@@ -152,6 +154,7 @@ def cap_mos_inst(
     return c_inst
 
 
+@gf.cell
 def draw_cap_mos(
     layout,
     type: str = "cap_nmos",
@@ -173,7 +176,7 @@ def draw_cap_mos(
      w      : Float of diff width
     """
 
-    c = gf.Component("cap_mos_dev")
+    c = gf.Component()
 
     con_size = 0.22
     con_sp = 0.28
@@ -521,8 +524,4 @@ def draw_cap_mos(
             )
         )  # guardring metal1
 
-    c.write_gds("cap_mos_temp.gds")
-    layout.read("cap_mos_temp.gds")
-    os.remove("cap_mos_temp.gds")
-
-    return layout.cell(c.name)
+    return c

--- a/cells/klayout/pymacros/cells/draw_diode.py
+++ b/cells/klayout/pymacros/cells/draw_diode.py
@@ -25,6 +25,7 @@ import numpy as np
 import os
 
 
+@gf.cell
 def draw_diode_nd2ps(
     layout,
     la: float = 0.1,
@@ -51,7 +52,7 @@ def draw_diode_nd2ps(
      pcmpgr     : Boolean of using P+ Guard Ring for Deep NWELL devices only
     """
 
-    c = gf.Component("diode_nd2ps_dev")
+    c = gf.Component()
 
     comp_spacing: float = 0.48
     np_enc_comp: float = 0.16
@@ -359,15 +360,10 @@ def draw_diode_nd2ps(
 
         lvpwell.center = diode_mk.center
 
-    # creating layout and cell in klayout
-
-    c.write_gds("diode_nd2ps_temp.gds")
-    layout.read("diode_nd2ps_temp.gds")
-    os.remove("diode_nd2ps_temp.gds")
-
-    return layout.cell(c.name)
+    return c
 
 
+@gf.cell
 def draw_diode_pd2nw(
     layout,
     la: float = 0.1,
@@ -392,7 +388,7 @@ def draw_diode_pd2nw(
      pcmpgr     : Boolean of using P+ Guard Ring for Deep NWELL devices only
     """
 
-    c = gf.Component("diode_pd2nw_dev")
+    c = gf.Component()
 
     comp_spacing: float = 0.48
     np_enc_comp: float = 0.16
@@ -692,15 +688,10 @@ def draw_diode_pd2nw(
             dg.xmin = ncmp.xmin - dg_enc_cmp
             dg.ymin = ncmp.ymin - dg_enc_cmp
 
-    # creating layout and cell in klayout
-
-    c.write_gds("diode_pd2nw_temp.gds")
-    layout.read("diode_pd2nw_temp.gds")
-    os.remove("diode_pd2nw_temp.gds")
-
-    return layout.cell(c.name)
+    return c
 
 
+@gf.cell
 def draw_diode_nw2ps(
     layout,
     la: float = 0.1,
@@ -722,7 +713,7 @@ def draw_diode_nw2ps(
      volt       : String of operating voltage of the diode [3.3V, 5V/6V]
     """
 
-    c = gf.Component("diode_nw2ps_dev")
+    c = gf.Component()
 
     comp_spacing: float = 0.48
     np_enc_comp: float = 0.16
@@ -832,15 +823,10 @@ def draw_diode_nw2ps(
         dg.xmin = pcmp.xmin - dg_enc_cmp
         dg.ymin = pcmp.ymin - dg_enc_cmp
 
-    # creating layout and cell in klayout
-
-    c.write_gds("diode_nw2ps_temp.gds")
-    layout.read("diode_nw2ps_temp.gds")
-    os.remove("diode_nw2ps_temp.gds")
-
-    return layout.cell(c.name)
+    return c
 
 
+@gf.cell
 def draw_diode_pw2dw(
     layout,
     la: float = 0.1,
@@ -863,7 +849,7 @@ def draw_diode_pw2dw(
      volt       : String of operating voltage of the diode [3.3V, 5V/6V]
     """
 
-    c = gf.Component("diode_pw2dw_dev")
+    c = gf.Component()
 
     comp_spacing: float = 0.92
     np_enc_comp: float = 0.16
@@ -1270,13 +1256,10 @@ def draw_diode_pw2dw(
 
     # creating layout and cell in klayout
 
-    c.write_gds("diode_pw2dw_temp.gds")
-    layout.read("diode_pw2dw_temp.gds")
-    os.remove("diode_pw2dw_temp.gds")
-
-    return layout.cell(c.name)
+    return c
 
 
+@gf.cell
 def draw_diode_dw2ps(
     layout,
     la: float = 0.1,
@@ -1298,7 +1281,7 @@ def draw_diode_dw2ps(
      volt       : String of operating voltage of the diode [3.3V, 5V/6V]
     """
 
-    c = gf.Component("diode_dw2ps_dev")
+    c = gf.Component()
 
     if volt == "5/6V":
         dn_enc_ncmp = 0.66
@@ -1669,15 +1652,10 @@ def draw_diode_dw2ps(
         dg.xmin = dn_rect.xmin - dg_enc_dn
         dg.ymin = dn_rect.ymin - dg_enc_dn
 
-    # creating layout and cell in klayout
-
-    c.write_gds("diode_dw2ps_temp.gds")
-    layout.read("diode_dw2ps_temp.gds")
-    os.remove("diode_dw2ps_temp.gds")
-
-    return layout.cell(c.name)
+    return c
 
 
+@gf.cell
 def draw_sc_diode(
     layout,
     la: float = 0.1,
@@ -1700,7 +1678,7 @@ def draw_sc_diode(
      pcmpgr     : Boolean of using P+ Guard Ring for Deep NWELL devices only
     """
 
-    c = gf.Component("sc_diode_dev")
+    c = gf.Component()
 
     sc_enc_comp = 0.16
     sc_comp_spacing = 0.28
@@ -2064,10 +2042,4 @@ def draw_sc_diode(
             )
         )  # guardring metal1
 
-    # creating layout and cell in klayout
-
-    c.write_gds("sc_diode_temp.gds")
-    layout.read("sc_diode_temp.gds")
-    os.remove("sc_diode_temp.gds")
-
-    return layout.cell(c.name)
+    return c

--- a/cells/klayout/pymacros/cells/draw_fet.py
+++ b/cells/klayout/pymacros/cells/draw_fet.py
@@ -1208,6 +1208,7 @@ def bulk_m1_check(bulk_con_area, m1_area, c_inst, bulk_con):
         bulk_m1.ymin = bulk_con.ymin - (bulk_m1.size[1] - bulk_con.size[1]) / 2
 
 
+@gf.cell
 def draw_nfet(
     layout,
     l_gate: float = 0.28,
@@ -1288,7 +1289,7 @@ def draw_nfet(
     sd_l = sd_l_con
 
     # gds components to store a single instance and the generated device
-    c = gf.Component("nfet_dev")
+    c = gf.Component()
 
     c_inst = gf.Component("dev_temp")
 
@@ -1707,12 +1708,7 @@ def draw_nfet(
             )
         )
 
-    # creating layout and cell in klayout
-    c.write_gds("nfet_temp.gds")
-    layout.read("nfet_temp.gds")
-    os.remove("nfet_temp.gds")
-
-    return layout.cell(c.name)
+    return c
 
 
 @gf.cell
@@ -1819,6 +1815,7 @@ def pfet_deep_nwell(
     return c
 
 
+@gf.cell
 def draw_pfet(
     layout,
     l_gate: float = 0.28,
@@ -1902,7 +1899,7 @@ def draw_pfet(
     sd_l = sd_l_con
 
     # gds components to store a single instance and the generated device
-    c = gf.Component("pfet_dev")
+    c = gf.Component()
 
     c_inst = gf.Component("dev_temp")
 
@@ -2335,15 +2332,10 @@ def draw_pfet(
         )
         # bulk guardring
 
-    # creating layout and cell in klayout
-
-    c.write_gds("pfet_temp.gds")
-    layout.read("pfet_temp.gds")
-    os.remove("pfet_temp.gds")
-
-    return layout.cell(c.name)
+    return c
 
 
+@gf.cell
 def draw_nfet_06v0_nvt(
     layout,
     l_gate: float = 1.8,
@@ -2410,7 +2402,7 @@ def draw_nfet_06v0_nvt(
     sd_l = sd_l_con
 
     # gds components to store a single instance and the generated device
-    c = gf.Component("nfet_nvt_dev")
+    c = gf.Component()
 
     c_inst = gf.Component("dev_temp")
 
@@ -2966,10 +2958,4 @@ def draw_nfet_06v0_nvt(
     nat.xmin = dg.xmin
     nat.ymin = dg.ymin
 
-    # creating layout and cell in klayout
-
-    c.write_gds("nfet_nvt_temp.gds")
-    layout.read("nfet_nvt_temp.gds")
-    os.remove("nfet_nvt_temp.gds")
-
-    return layout.cell(c.name)
+    return c

--- a/cells/klayout/pymacros/cells/draw_res.py
+++ b/cells/klayout/pymacros/cells/draw_res.py
@@ -23,6 +23,7 @@ from .via_generator import via_generator, via_stack
 import os
 
 
+@gf.cell
 def draw_metal_res(
     layout,
     l_res: float = 0.1,
@@ -42,7 +43,7 @@ def draw_metal_res(
      w      : Float of diff width
     """
 
-    c = gf.Component("res_dev")
+    c = gf.Component()
 
     m_ext = 0.28
 
@@ -104,13 +105,7 @@ def draw_metal_res(
             layer=m_lbl_layer,
         )
 
-    # creating layout and cell in klayout
-
-    c.write_gds("res_temp.gds")
-    layout.read("res_temp.gds")
-    os.remove("res_temp.gds")
-
-    return layout.cell(c.name)
+    return c
 
 
 @gf.cell
@@ -401,6 +396,7 @@ def plus_res_inst(
     return c
 
 
+@gf.cell
 def draw_nplus_res(
     layout,
     l_res: float = 0.1,
@@ -415,7 +411,7 @@ def draw_nplus_res(
     sub_lbl: str = "",
 ) -> gf.Component:
 
-    c = gf.Component("res_dev")
+    c = gf.Component()
 
     lvpwell_enc_cmp = 0.43
     dn_enc_lvpwell = 2.5
@@ -474,13 +470,10 @@ def draw_nplus_res(
         if pcmpgr == 1:
             c.add_ref(pcmpgr_gen(dn_rect=dn_rect, grw=sub_w))
 
-    c.write_gds("res_temp.gds")
-    layout.read("res_temp.gds")
-    os.remove("res_temp.gds")
-
-    return layout.cell(c.name)
+    return c
 
 
+@gf.cell
 def draw_pplus_res(
     layout,
     l_res: float = 0.1,
@@ -495,7 +488,7 @@ def draw_pplus_res(
     sub_lbl: str = "",
 ) -> gf.Component:
 
-    c = gf.Component("res_dev")
+    c = gf.Component()
 
     nw_enc_pcmp = 0.6
     dn_enc_ncmp = 0.66
@@ -558,11 +551,7 @@ def draw_pplus_res(
         nw_rect.xmin = r_inst.xmin - nw_enc_pcmp
         nw_rect.ymin = r_inst.ymin - nw_enc_pcmp
 
-    c.write_gds("res_temp.gds")
-    layout.read("res_temp.gds")
-    os.remove("res_temp.gds")
-
-    return layout.cell(c.name)
+    return c
 
 
 @gf.cell
@@ -703,6 +692,7 @@ def polyf_res_inst(
     return c
 
 
+@gf.cell
 def draw_npolyf_res(
     layout,
     l_res: float = 0.1,
@@ -716,7 +706,7 @@ def draw_npolyf_res(
     sub_lbl: str = "",
 ) -> gf.Component:
 
-    c = gf.Component("res_dev")
+    c = gf.Component()
 
     sub_w = 0.36
     sub_sp = 0.26 if deepnwell == 0 else 0.4
@@ -766,13 +756,10 @@ def draw_npolyf_res(
         if pcmpgr == 1:
             c.add_ref(pcmpgr_gen(dn_rect=dn_rect, grw=sub_w))
 
-    c.write_gds("res_temp.gds")
-    layout.read("res_temp.gds")
-    os.remove("res_temp.gds")
-
-    return layout.cell(c.name)
+    return c
 
 
+@gf.cell
 def draw_ppolyf_res(
     layout,
     l_res: float = 0.1,
@@ -786,7 +773,7 @@ def draw_ppolyf_res(
     sub_lbl: str = "",
 ) -> gf.Component:
 
-    c = gf.Component("res_dev")
+    c = gf.Component()
 
     sub_w = 0.36
     dn_enc_ncmp = 0.66
@@ -841,13 +828,10 @@ def draw_ppolyf_res(
         if pcmpgr == 1:
             c.add_ref(pcmpgr_gen(dn_rect=dn_rect, grw=sub_w))
 
-    c.write_gds("res_temp.gds")
-    layout.read("res_temp.gds")
-    os.remove("res_temp.gds")
-
-    return layout.cell(c.name)
+    return c
 
 
+@gf.cell
 def draw_ppolyf_u_high_Rs_res(
     layout,
     l_res: float = 0.42,
@@ -861,7 +845,7 @@ def draw_ppolyf_u_high_Rs_res(
     sub_lbl: str = "",
 ) -> gf.Component:
 
-    c = gf.Component("res_dev")
+    c = gf.Component()
 
     dn_enc_ncmp = 0.62 if volt == "3.3V" else 0.66
     dn_enc_poly2 = 1.34
@@ -1054,13 +1038,10 @@ def draw_ppolyf_u_high_Rs_res(
             dg.xmin = resis_mk.xmin
             dg.ymin = resis_mk.ymin
 
-    c.write_gds("res_temp.gds")
-    layout.read("res_temp.gds")
-    os.remove("res_temp.gds")
-
-    return layout.cell(c.name)
+    return c
 
 
+@gf.cell
 def draw_well_res(
     layout,
     l_res: float = 0.42,
@@ -1073,7 +1054,7 @@ def draw_well_res(
     sub_lbl: str = "",
 ) -> gf.Component:
 
-    c = gf.Component("res_dev")
+    c = gf.Component()
 
     nw_res_ext = 0.48
     nw_res_enc = 0.5
@@ -1230,8 +1211,4 @@ def draw_well_res(
             layer=layer["metal1_label"],
         )
 
-    c.write_gds("res_temp.gds")
-    layout.read("res_temp.gds")
-    os.remove("res_temp.gds")
-
-    return layout.cell(c.name)
+    return c

--- a/cells/klayout/pymacros/cells/fet.py
+++ b/cells/klayout/pymacros/cells/fet.py
@@ -18,6 +18,8 @@
 import pya
 from .draw_fet import draw_nfet, draw_nfet_06v0_nvt, draw_pfet
 
+from .pcell_utilities import gf_to_pya
+
 fet_3p3_l = float(0.28)
 fet_3p3_w = float(0.22)
 fet_w_con = float(0.36)
@@ -164,7 +166,8 @@ class nfet(pya.PCellDeclarationHelper):
         return pya.Trans(self.shape.bbox().center())
 
     def produce_impl(self):
-        nfet_instance = draw_nfet(
+        instance = draw_nfet(
+            "nfet_dev",
             layout=self.layout,
             l_gate=self.l_gate,
             w_gate=self.w_gate,
@@ -186,8 +189,12 @@ class nfet(pya.PCellDeclarationHelper):
             sub_lbl=self.sub_lbl,
             patt_lbl=self.patt_lbl,
         )
+
+        # creating layout and cell in klayout
+        instance = gf_to_pya(self.layout, instance, "nfet")
+
         write_cells = pya.CellInstArray(
-            nfet_instance.cell_index(),
+            instance.cell_index(),
             pya.Trans(pya.Point(0, 0)),
             pya.Vector(0, 0),
             pya.Vector(0, 0),
@@ -322,6 +329,7 @@ class pfet(pya.PCellDeclarationHelper):
 
     def produce_impl(self):
         instance = draw_pfet(
+            "pfet_dev",
             self.layout,
             l_gate=self.l_gate,
             w_gate=self.w_gate,
@@ -343,6 +351,10 @@ class pfet(pya.PCellDeclarationHelper):
             sub_lbl=self.sub_lbl,
             patt_lbl=self.patt_lbl,
         )
+
+        # creating layout and cell in klayout
+        instance = gf_to_pya(self.layout, instance, "pfet")
+        
         write_cells = pya.CellInstArray(
             instance.cell_index(),
             pya.Trans(pya.Point(0, 0)),
@@ -459,6 +471,7 @@ class nfet_06v0_nvt(pya.PCellDeclarationHelper):
 
     def produce_impl(self):
         instance = draw_nfet_06v0_nvt(
+            "nfet_nvt_dev",
             self.layout,
             l_gate=self.l_gate,
             w_gate=self.w_gate,
@@ -477,6 +490,9 @@ class nfet_06v0_nvt(pya.PCellDeclarationHelper):
             sub_lbl=self.sub_lbl,
             patt_lbl=self.patt_lbl,
         )
+
+        # creating layout and cell in klayout
+        instance = gf_to_pya(self.layout, instance, "nfet_nvt")
 
         write_cells = pya.CellInstArray(
             instance.cell_index(),

--- a/cells/klayout/pymacros/cells/pcell_utilities.py
+++ b/cells/klayout/pymacros/cells/pcell_utilities.py
@@ -1,0 +1,10 @@
+import gdsfactory as gf
+import pya
+import os
+
+def gf_to_pya(layout, c: gf.Component, device_name: str):
+    c.write_gds(str(device_name) + "_temp.gds")
+    layout.read(str(device_name) + "_temp.gds")
+    os.remove(str(device_name) + "_temp.gds")
+
+    return layout.cell(c.name)

--- a/cells/klayout/pymacros/cells/res.py
+++ b/cells/klayout/pymacros/cells/res.py
@@ -28,6 +28,8 @@ from .draw_res import (
     draw_well_res,
 )
 
+from .pcell_utilities import gf_to_pya
+
 rm1_l = 0.23
 rm1_w = 0.23
 
@@ -197,7 +199,8 @@ class metal_resistor(pya.PCellDeclarationHelper):
     def produce_impl(self):
         dbu_PERCISION = 1 / self.layout.dbu
 
-        np_instance = draw_metal_res(
+        instance = draw_metal_res(
+            "res_dev",
             layout=self.layout,
             l_res=self.l_res,
             w_res=self.w_res,
@@ -207,8 +210,12 @@ class metal_resistor(pya.PCellDeclarationHelper):
             r0_lbl=self.r0_lbl,
             r1_lbl=self.r1_lbl,
         )
+
+        # creating layout and cell in klayout
+        instance = gf_to_pya(self.layout, instance, "res")
+
         write_cells = pya.CellInstArray(
-            np_instance.cell_index(),
+            instance.cell_index(),
             pya.Trans(pya.Point(0, 0)),
             pya.Vector(self.x_spacing * dbu_PERCISION, 0),
             pya.Vector(0, self.y_spacing * dbu_PERCISION),
@@ -294,7 +301,8 @@ class nplus_s_resistor(pya.PCellDeclarationHelper):
 
     def produce_impl(self):
         dbu_PERCISION = 1 / self.layout.dbu
-        np_instance = draw_nplus_res(
+        instance = draw_nplus_res(
+            "res_dev",
             layout=self.layout,
             l_res=self.l_res,
             w_res=self.w_res,
@@ -307,8 +315,12 @@ class nplus_s_resistor(pya.PCellDeclarationHelper):
             r1_lbl=self.r1_lbl,
             sub_lbl=self.sub_lbl,
         )
+
+        # creating layout and cell in klayout
+        instance = gf_to_pya(self.layout, instance, "res")
+
         write_cells = pya.CellInstArray(
-            np_instance.cell_index(),
+            instance.cell_index(),
             pya.Trans(pya.Point(0, 0)),
             pya.Vector(self.x_spacing * dbu_PERCISION, 0),
             pya.Vector(0, self.y_spacing * dbu_PERCISION),
@@ -393,7 +405,8 @@ class pplus_s_resistor(pya.PCellDeclarationHelper):
 
     def produce_impl(self):
         dbu_PERCISION = 1 / self.layout.dbu
-        np_instance = draw_pplus_res(
+        instance = draw_pplus_res(
+            "res_dev",
             layout=self.layout,
             l_res=self.l_res,
             w_res=self.w_res,
@@ -405,8 +418,12 @@ class pplus_s_resistor(pya.PCellDeclarationHelper):
             r1_lbl=self.r1_lbl,
             sub_lbl=self.sub_lbl,
         )
+
+        # creating layout and cell in klayout
+        instance = gf_to_pya(self.layout, instance, "res")
+
         write_cells = pya.CellInstArray(
-            np_instance.cell_index(),
+            instance.cell_index(),
             pya.Trans(pya.Point(0, 0)),
             pya.Vector(self.x_spacing * dbu_PERCISION, 0),
             pya.Vector(0, self.y_spacing * dbu_PERCISION),
@@ -492,7 +509,8 @@ class nplus_u_resistor(pya.PCellDeclarationHelper):
 
     def produce_impl(self):
         dbu_PERCISION = 1 / self.layout.dbu
-        np_instance = draw_nplus_res(
+        instance = draw_nplus_res(
+            "res_dev",
             layout=self.layout,
             l_res=self.l_res,
             w_res=self.w_res,
@@ -505,8 +523,12 @@ class nplus_u_resistor(pya.PCellDeclarationHelper):
             r1_lbl=self.r1_lbl,
             sub_lbl=self.sub_lbl,
         )
+
+        # creating layout and cell in klayout
+        instance = gf_to_pya(self.layout, instance, "res")
+
         write_cells = pya.CellInstArray(
-            np_instance.cell_index(),
+            instance.cell_index(),
             pya.Trans(pya.Point(0, 0)),
             pya.Vector(self.x_spacing * dbu_PERCISION, 0),
             pya.Vector(0, self.y_spacing * dbu_PERCISION),
@@ -591,7 +613,8 @@ class pplus_u_resistor(pya.PCellDeclarationHelper):
 
     def produce_impl(self):
         dbu_PERCISION = 1 / self.layout.dbu
-        np_instance = draw_pplus_res(
+        instance = draw_pplus_res(
+            "res_dev",
             layout=self.layout,
             l_res=self.l_res,
             w_res=self.w_res,
@@ -603,8 +626,12 @@ class pplus_u_resistor(pya.PCellDeclarationHelper):
             r1_lbl=self.r1_lbl,
             sub_lbl=self.sub_lbl,
         )
+
+        # creating layout and cell in klayout
+        instance = gf_to_pya(self.layout, instance, "res")
+
         write_cells = pya.CellInstArray(
-            np_instance.cell_index(),
+            instance.cell_index(),
             pya.Trans(pya.Point(0, 0)),
             pya.Vector(self.x_spacing * dbu_PERCISION, 0),
             pya.Vector(0, self.y_spacing * dbu_PERCISION),
@@ -687,7 +714,8 @@ class nwell_resistor(pya.PCellDeclarationHelper):
 
     def produce_impl(self):
         dbu_PERCISION = 1 / self.layout.dbu
-        np_instance = draw_well_res(
+        instance = draw_well_res(
+            "res_dev",
             layout=self.layout,
             l_res=self.l_res,
             w_res=self.w_res,
@@ -698,8 +726,12 @@ class nwell_resistor(pya.PCellDeclarationHelper):
             r1_lbl=self.r1_lbl,
             sub_lbl=self.sub_lbl,
         )
+
+        # creating layout and cell in klayout
+        instance = gf_to_pya(self.layout, instance, "res")
+
         write_cells = pya.CellInstArray(
-            np_instance.cell_index(),
+            instance.cell_index(),
             pya.Trans(pya.Point(0, 0)),
             pya.Vector(self.x_spacing * dbu_PERCISION, 0),
             pya.Vector(0, self.y_spacing * dbu_PERCISION),
@@ -783,7 +815,8 @@ class pwell_resistor(pya.PCellDeclarationHelper):
 
     def produce_impl(self):
         dbu_PERCISION = 1 / self.layout.dbu
-        np_instance = draw_well_res(
+        instance = draw_well_res(
+            "res_dev",
             layout=self.layout,
             l_res=self.l_res,
             w_res=self.w_res,
@@ -794,8 +827,12 @@ class pwell_resistor(pya.PCellDeclarationHelper):
             r1_lbl=self.r1_lbl,
             sub_lbl=self.sub_lbl,
         )
+
+        # creating layout and cell in klayout
+        instance = gf_to_pya(self.layout, instance, "res")
+
         write_cells = pya.CellInstArray(
-            np_instance.cell_index(),
+            instance.cell_index(),
             pya.Trans(pya.Point(0, 0)),
             pya.Vector(self.x_spacing * dbu_PERCISION, 0),
             pya.Vector(0, self.y_spacing * dbu_PERCISION),
@@ -880,7 +917,8 @@ class npolyf_s_resistor(pya.PCellDeclarationHelper):
 
     def produce_impl(self):
         dbu_PERCISION = 1 / self.layout.dbu
-        np_instance = draw_npolyf_res(
+        instance = draw_npolyf_res(
+            "res_dev",
             layout=self.layout,
             l_res=self.l_res,
             w_res=self.w_res,
@@ -892,8 +930,12 @@ class npolyf_s_resistor(pya.PCellDeclarationHelper):
             r1_lbl=self.r1_lbl,
             sub_lbl=self.sub_lbl,
         )
+
+        # creating layout and cell in klayout
+        instance = gf_to_pya(self.layout, instance, "res")
+
         write_cells = pya.CellInstArray(
-            np_instance.cell_index(),
+            instance.cell_index(),
             pya.Trans(pya.Point(0, 0)),
             pya.Vector(self.x_spacing * dbu_PERCISION, 0),
             pya.Vector(0, self.y_spacing * dbu_PERCISION),
@@ -978,7 +1020,8 @@ class ppolyf_s_resistor(pya.PCellDeclarationHelper):
 
     def produce_impl(self):
         dbu_PERCISION = 1 / self.layout.dbu
-        np_instance = draw_ppolyf_res(
+        instance = draw_ppolyf_res(
+            "res_dev",
             layout=self.layout,
             l_res=self.l_res,
             w_res=self.w_res,
@@ -990,8 +1033,12 @@ class ppolyf_s_resistor(pya.PCellDeclarationHelper):
             r1_lbl=self.r1_lbl,
             sub_lbl=self.sub_lbl,
         )
+
+        # creating layout and cell in klayout
+        instance = gf_to_pya(self.layout, instance, "res")
+
         write_cells = pya.CellInstArray(
-            np_instance.cell_index(),
+            instance.cell_index(),
             pya.Trans(pya.Point(0, 0)),
             pya.Vector(self.x_spacing * dbu_PERCISION, 0),
             pya.Vector(0, self.y_spacing * dbu_PERCISION),
@@ -1076,7 +1123,8 @@ class npolyf_u_resistor(pya.PCellDeclarationHelper):
 
     def produce_impl(self):
         dbu_PERCISION = 1 / self.layout.dbu
-        np_instance = draw_npolyf_res(
+        instance = draw_npolyf_res(
+            "res_dev",
             layout=self.layout,
             l_res=self.l_res,
             w_res=self.w_res,
@@ -1088,8 +1136,12 @@ class npolyf_u_resistor(pya.PCellDeclarationHelper):
             r1_lbl=self.r1_lbl,
             sub_lbl=self.sub_lbl,
         )
+
+        # creating layout and cell in klayout
+        instance = gf_to_pya(self.layout, instance, "res")
+        
         write_cells = pya.CellInstArray(
-            np_instance.cell_index(),
+            instance.cell_index(),
             pya.Trans(pya.Point(0, 0)),
             pya.Vector(self.x_spacing * dbu_PERCISION, 0),
             pya.Vector(0, self.y_spacing * dbu_PERCISION),
@@ -1174,7 +1226,8 @@ class ppolyf_u_resistor(pya.PCellDeclarationHelper):
 
     def produce_impl(self):
         dbu_PERCISION = 1 / self.layout.dbu
-        np_instance = draw_ppolyf_res(
+        instance = draw_ppolyf_res(
+            "res_dev",
             layout=self.layout,
             l_res=self.l_res,
             w_res=self.w_res,
@@ -1186,8 +1239,12 @@ class ppolyf_u_resistor(pya.PCellDeclarationHelper):
             r1_lbl=self.r1_lbl,
             sub_lbl=self.sub_lbl,
         )
+
+        # creating layout and cell in klayout
+        instance = gf_to_pya(self.layout, instance, "res")
+        
         write_cells = pya.CellInstArray(
-            np_instance.cell_index(),
+            instance.cell_index(),
             pya.Trans(pya.Point(0, 0)),
             pya.Vector(self.x_spacing * dbu_PERCISION, 0),
             pya.Vector(0, self.y_spacing * dbu_PERCISION),
@@ -1280,7 +1337,8 @@ class ppolyf_u_high_Rs_resistor(pya.PCellDeclarationHelper):
 
     def produce_impl(self):
         dbu_PERCISION = 1 / self.layout.dbu
-        np_instance = draw_ppolyf_u_high_Rs_res(
+        instance = draw_ppolyf_u_high_Rs_res(
+            "res_dev",
             layout=self.layout,
             l_res=self.l_res,
             w_res=self.w_res,
@@ -1292,8 +1350,12 @@ class ppolyf_u_high_Rs_resistor(pya.PCellDeclarationHelper):
             r1_lbl=self.r1_lbl,
             sub_lbl=self.sub_lbl,
         )
+
+        # creating layout and cell in klayout
+        instance = gf_to_pya(self.layout, instance, "res")
+        
         write_cells = pya.CellInstArray(
-            np_instance.cell_index(),
+            instance.cell_index(),
             pya.Trans(pya.Point(0, 0)),
             pya.Vector(self.x_spacing * dbu_PERCISION, 0),
             pya.Vector(0, self.y_spacing * dbu_PERCISION),

--- a/cells/klayout/pymacros/cells/via_generator.py
+++ b/cells/klayout/pymacros/cells/via_generator.py
@@ -226,6 +226,7 @@ def via_stack(
     return c
 
 
+@gf.cell
 def draw_via_dev(
     layout,
     x_min: float = 0,
@@ -234,7 +235,7 @@ def draw_via_dev(
     y_max: float = 2,
     metal_level: str = "M1",
     base_layer: str = "comp",
-):
+) -> gf.Component:
 
     """
 
@@ -255,7 +256,7 @@ def draw_via_dev(
 
     """
 
-    c = gf.Component("via_stack_dev")
+    c = gf.Component()
 
     # vias dimensions
     x_range = x_max - x_min
@@ -394,8 +395,4 @@ def draw_via_dev(
         )
         c.add_ref(v5)
 
-    c.write_gds("via_stack_temp.gds")
-    layout.read("via_stack_temp.gds")
-    os.remove("via_stack_temp.gds")
-
-    return layout.cell(c.name)
+    return c

--- a/cells/klayout/pymacros/cells/vias_gen.py
+++ b/cells/klayout/pymacros/cells/vias_gen.py
@@ -19,6 +19,8 @@
 import pya
 from .via_generator import draw_via_dev
 
+from .pcell_utilities import gf_to_pya
+
 via_size = 0.26
 via_enc = 0.07
 mt_min = 0.75
@@ -98,7 +100,8 @@ class via_dev(pya.PCellDeclarationHelper):
 
     def produce_impl(self):
 
-        via_instance = draw_via_dev(
+        instance = draw_via_dev(
+            "via_stack_dev",
             self.layout,
             x_max=self.x_max,
             y_max=self.y_max,
@@ -106,8 +109,11 @@ class via_dev(pya.PCellDeclarationHelper):
             base_layer=self.base_layer,
         )
 
+        # creating layout and cell in klayout
+        instance = gf_to_pya(self.layout, instance, "via_stack")
+
         write_cells = pya.CellInstArray(
-            via_instance.cell_index(),
+            instance.cell_index(),
             pya.Trans(pya.Point(0, 0)),
             pya.Vector(0, 0),
             pya.Vector(0, 0),


### PR DESCRIPTION
Some of the PDK's `draw_*` functions do not currently return instances of `gf.Component`. This difficults working directly with GDSFactory to, for instance, design an inverter without depending on klayout.
This happens because some of these functions, such as `draw_nfet`, generates a temporary GDS and then it's registered in the layout, removing all hierarchies and abstractions that GDSFactory uses.
This Pull Request moves that operation into the `produce_impl` method of the Pcell.

Changes introduced:

- The "layout" attribute of certain `draw_*` functions is not used. 
- All the `draw_*` functions return an instance of gf.Component.
- The `gf_to_pya()` function is defined to perform the registration in klayout. All PCells occupy it.
- The `efuse` and `bjt` cells are not modified because their structure is different. That can be another pull request.

Things that can be a problem:

- Some functions, like `draw_nfet`, use named cells. The documentation don't recommend it 
because it can create duplicated cells. https://gdsfactory.github.io/gdsfactory/notebooks/11_best_practices.html
- I have not executed any test case.