### PR TITLE
Add all missing xschem gf180mcu symbols 

### DIFF
--- a/cells/xschem/symbols/cap_mim_1f0fF.sym
+++ b/cells/xschem/symbols/cap_mim_1f0fF.sym
@@ -1,4 +1,4 @@
-v {xschem version=3.4.5 file_version=1.2
+v {xschem version=3.1.0 file_version=1.2
 
 * Copyright 2022 GlobalFoundries PDK Authors
 *
@@ -16,24 +16,24 @@ v {xschem version=3.4.5 file_version=1.2
 
 }
 G {}
-K {type=vertical_pnp
-format="@spiceprefix@name @pinlist @model m=@m"
-template="name=Q1
-model=pnp_10p00x10p00
+K {type=moscap
+format="@spiceprefix@name @pinlist @model c_width=@W c_length=@L m=@m"
+template="name=C1
+W=1e-6
+L=1e-6
+model=cap_mim_1f0fF
 spiceprefix=X
 m=1"
 }
 V {}
 S {}
 E {}
-L 4 0 -30 0 30 {}
-L 4 -20 0 0 0 {}
-L 4 11.25 -21.25 20 -30 {}
-L 4 0 10 20 30 {}
-B 5 17.5 27.5 22.5 32.5 {name=C dir=inout pinnumber=3}
-B 5 -22.5 -2.5 -17.5 2.5 {name=B dir=in pinnumber=1}
-B 5 17.5 -32.5 22.5 -27.5 {name=E dir=inout pinnumber=2}
-P 4 4 0 -10 6.25 -26.25 16.25 -16.25 0 -10 {fill=true}
-T {m=@m} 22.5 11.25 0 0 0.2 0.2 {layer=13}
-T {@model} 22.5 -15 0 0 0.2 0.2 {}
-T {@spiceprefix@name} 22.5 -27.5 0 0 0.2 0.2 {}
+L 4 0 5 0 30 {}
+L 4 0 -30 0 -5 {}
+L 4 -15 -5 15 -5 {}
+L 4 -15 5 15 5 {}
+B 5 -2.5 -32.5 2.5 -27.5 {name=G dir=inout propag=1 pinnumber=2}
+B 5 -2.5 27.5 2.5 32.5 {name=B dir=inout propag=0 pinnumber=1}
+T {@spiceprefix@name} 20 -28.75 0 0 0.2 0.2 {}
+T {@m * @W / @L} 20 6.25 0 0 0.2 0.2 {layer=13}
+T {@model} 20 -11.25 0 0 0.2 0.2 {}

--- a/cells/xschem/symbols/cap_mim_1f5fF.sym
+++ b/cells/xschem/symbols/cap_mim_1f5fF.sym
@@ -1,4 +1,4 @@
-v {xschem version=3.4.5 file_version=1.2
+v {xschem version=3.1.0 file_version=1.2
 
 * Copyright 2022 GlobalFoundries PDK Authors
 *
@@ -16,24 +16,24 @@ v {xschem version=3.4.5 file_version=1.2
 
 }
 G {}
-K {type=vertical_pnp
-format="@spiceprefix@name @pinlist @model m=@m"
-template="name=Q1
-model=pnp_10p00x10p00
+K {type=moscap
+format="@spiceprefix@name @pinlist @model c_width=@W c_length=@L m=@m"
+template="name=C1
+W=1e-6
+L=1e-6
+model=cap_mim_1f5fF
 spiceprefix=X
 m=1"
 }
 V {}
 S {}
 E {}
-L 4 0 -30 0 30 {}
-L 4 -20 0 0 0 {}
-L 4 11.25 -21.25 20 -30 {}
-L 4 0 10 20 30 {}
-B 5 17.5 27.5 22.5 32.5 {name=C dir=inout pinnumber=3}
-B 5 -22.5 -2.5 -17.5 2.5 {name=B dir=in pinnumber=1}
-B 5 17.5 -32.5 22.5 -27.5 {name=E dir=inout pinnumber=2}
-P 4 4 0 -10 6.25 -26.25 16.25 -16.25 0 -10 {fill=true}
-T {m=@m} 22.5 11.25 0 0 0.2 0.2 {layer=13}
-T {@model} 22.5 -15 0 0 0.2 0.2 {}
-T {@spiceprefix@name} 22.5 -27.5 0 0 0.2 0.2 {}
+L 4 0 5 0 30 {}
+L 4 0 -30 0 -5 {}
+L 4 -15 -5 15 -5 {}
+L 4 -15 5 15 5 {}
+B 5 -2.5 -32.5 2.5 -27.5 {name=G dir=inout propag=1 pinnumber=2}
+B 5 -2.5 27.5 2.5 32.5 {name=B dir=inout propag=0 pinnumber=1}
+T {@spiceprefix@name} 20 -28.75 0 0 0.2 0.2 {}
+T {@m * @W / @L} 20 6.25 0 0 0.2 0.2 {layer=13}
+T {@model} 20 -11.25 0 0 0.2 0.2 {}

--- a/cells/xschem/symbols/cap_mim_2f0fF.sym
+++ b/cells/xschem/symbols/cap_mim_2f0fF.sym
@@ -1,4 +1,4 @@
-v {xschem version=3.4.5 file_version=1.2
+v {xschem version=3.1.0 file_version=1.2
 
 * Copyright 2022 GlobalFoundries PDK Authors
 *
@@ -16,24 +16,24 @@ v {xschem version=3.4.5 file_version=1.2
 
 }
 G {}
-K {type=vertical_pnp
-format="@spiceprefix@name @pinlist @model m=@m"
-template="name=Q1
-model=pnp_10p00x10p00
+K {type=moscap
+format="@spiceprefix@name @pinlist @model c_width=@W c_length=@L m=@m"
+template="name=C1
+W=1e-6
+L=1e-6
+model=cap_mim_2f0fF
 spiceprefix=X
 m=1"
 }
 V {}
 S {}
 E {}
-L 4 0 -30 0 30 {}
-L 4 -20 0 0 0 {}
-L 4 11.25 -21.25 20 -30 {}
-L 4 0 10 20 30 {}
-B 5 17.5 27.5 22.5 32.5 {name=C dir=inout pinnumber=3}
-B 5 -22.5 -2.5 -17.5 2.5 {name=B dir=in pinnumber=1}
-B 5 17.5 -32.5 22.5 -27.5 {name=E dir=inout pinnumber=2}
-P 4 4 0 -10 6.25 -26.25 16.25 -16.25 0 -10 {fill=true}
-T {m=@m} 22.5 11.25 0 0 0.2 0.2 {layer=13}
-T {@model} 22.5 -15 0 0 0.2 0.2 {}
-T {@spiceprefix@name} 22.5 -27.5 0 0 0.2 0.2 {}
+L 4 0 5 0 30 {}
+L 4 0 -30 0 -5 {}
+L 4 -15 -5 15 -5 {}
+L 4 -15 5 15 5 {}
+B 5 -2.5 -32.5 2.5 -27.5 {name=G dir=inout propag=1 pinnumber=2}
+B 5 -2.5 27.5 2.5 32.5 {name=B dir=inout propag=0 pinnumber=1}
+T {@spiceprefix@name} 20 -28.75 0 0 0.2 0.2 {}
+T {@m * @W / @L} 20 6.25 0 0 0.2 0.2 {layer=13}
+T {@model} 20 -11.25 0 0 0.2 0.2 {}

--- a/cells/xschem/symbols/cap_mim_2p0fF.sym
+++ b/cells/xschem/symbols/cap_mim_2p0fF.sym
@@ -1,4 +1,4 @@
-v {xschem version=3.1.0 file_version=1.2
+v {xschem version=3.4.5 file_version=1.2
 
 * Copyright 2022 GlobalFoundries PDK Authors
 *
@@ -37,3 +37,6 @@ B 5 -2.5 27.5 2.5 32.5 {name=B dir=inout propag=0 pinnumber=1}
 T {@spiceprefix@name} 20 -28.75 0 0 0.2 0.2 {}
 T {@m * @W / @L} 20 6.25 0 0 0.2 0.2 {layer=13}
 T {@model} 20 -11.25 0 0 0.2 0.2 {}
+T {Deprecated:
+Replace with
+cap_mim_2f0fF.sym} -95 -25 0 0 0.15 0.15 { layer=7}

--- a/cells/xschem/symbols/cap_mim_analog.sym
+++ b/cells/xschem/symbols/cap_mim_analog.sym
@@ -21,21 +21,33 @@ format="@spiceprefix@name @pinlist @model c_width=@W c_length=@L m=@m"
 template="name=C1
 W=1e-6
 L=1e-6
-model=cap_pmos_03v3
+model=cap_mim_2f0_m3m4_noshield
 spiceprefix=X
 m=1"
-}
+
+available_models="
+ cap_mim_1f5_m2m3_noshield
+ cap_mim_1f0_m2m3_noshield
+ cap_mim_2f0_m2m3_noshield
+ cap_mim_1f5_m3m4_noshield
+ cap_mim_1f0_m3m4_noshield
+ cap_mim_2f0_m3m4_noshield
+ cap_mim_1f5_m4m5_noshield
+ cap_mim_1f0_m4m5_noshield
+ cap_mim_2f0_m4m5_noshield
+ cap_mim_1f5_m5m6_noshield
+ cap_mim_1f0_m5m6_noshield
+ cap_mim_2f0_m5m6_noshield
+"}
 V {}
 S {}
 E {}
-L 4 0 -30 0 -10 {}
+L 4 0 5 0 30 {}
+L 4 0 -30 0 -5 {}
+L 4 -15 -5 15 -5 {}
 L 4 -15 5 15 5 {}
-L 4 0 15 0 30 {}
-B 4 -15 -10 15 -5 {}
-B 5 -2.5 27.5 2.5 32.5 {name=G dir=inout propag=1 pinnumber=2}
-B 5 -2.5 -32.5 2.5 -27.5 {name=B dir=inout propag=0 pinnumber=1}
-A 4 0 10 5 90 360 {}
+B 5 -2.5 -32.5 2.5 -27.5 {name=G dir=inout propag=1 pinnumber=2}
+B 5 -2.5 27.5 2.5 32.5 {name=B dir=inout propag=0 pinnumber=1}
+T {@spiceprefix@name} 20 -28.75 0 0 0.2 0.2 {}
 T {@m * @W / @L} 20 6.25 0 0 0.2 0.2 {layer=13}
 T {@model} 20 -11.25 0 0 0.2 0.2 {}
-T {@spiceprefix@name} 20 -28.75 0 0 0.2 0.2 {}
-T {NW} -22.5 -25 0 0 0.2 0.2 { layer=4}

--- a/cells/xschem/symbols/cap_nmos_03v3_b.sym
+++ b/cells/xschem/symbols/cap_nmos_03v3_b.sym
@@ -16,24 +16,25 @@ v {xschem version=3.4.5 file_version=1.2
 
 }
 G {}
-K {type=vertical_pnp
-format="@spiceprefix@name @pinlist @model m=@m"
-template="name=Q1
-model=pnp_10p00x10p00
+K {type=moscap
+format="@spiceprefix@name @pinlist @model c_width=@W c_length=@L m=@m"
+template="name=C1
+W=1e-6
+L=1e-6
+model=cap_nmos_03v3_b
 spiceprefix=X
 m=1"
 }
 V {}
 S {}
 E {}
-L 4 0 -30 0 30 {}
-L 4 -20 0 0 0 {}
-L 4 11.25 -21.25 20 -30 {}
-L 4 0 10 20 30 {}
-B 5 17.5 27.5 22.5 32.5 {name=C dir=inout pinnumber=3}
-B 5 -22.5 -2.5 -17.5 2.5 {name=B dir=in pinnumber=1}
-B 5 17.5 -32.5 22.5 -27.5 {name=E dir=inout pinnumber=2}
-P 4 4 0 -10 6.25 -26.25 16.25 -16.25 0 -10 {fill=true}
-T {m=@m} 22.5 11.25 0 0 0.2 0.2 {layer=13}
-T {@model} 22.5 -15 0 0 0.2 0.2 {}
-T {@spiceprefix@name} 22.5 -27.5 0 0 0.2 0.2 {}
+L 4 0 10 0 30 {}
+L 4 0 -30 0 -5 {}
+L 4 -15 -5 15 -5 {}
+B 4 -15 5 15 10 {}
+B 5 -2.5 -32.5 2.5 -27.5 {name=G dir=inout propag=1 pinnumber=2}
+B 5 -2.5 27.5 2.5 32.5 {name=B dir=inout propag=0 pinnumber=1}
+T {@m * @W / @L} 20 6.25 0 0 0.2 0.2 {layer=13}
+T {@model} 20 -11.25 0 0 0.2 0.2 {}
+T {@spiceprefix@name} 20 -28.75 0 0 0.2 0.2 {}
+T {NW} -25 12.5 0 0 0.2 0.2 { layer=4}

--- a/cells/xschem/symbols/cap_nmos_06v0_b.sym
+++ b/cells/xschem/symbols/cap_nmos_06v0_b.sym
@@ -16,24 +16,25 @@ v {xschem version=3.4.5 file_version=1.2
 
 }
 G {}
-K {type=vertical_pnp
-format="@spiceprefix@name @pinlist @model m=@m"
-template="name=Q1
-model=pnp_10p00x10p00
+K {type=moscap
+format="@spiceprefix@name @pinlist @model c_width=@W c_length=@L m=@m"
+template="name=C1
+W=1e-6
+L=1e-6
+model=cap_nmos_06v0_b
 spiceprefix=X
 m=1"
 }
 V {}
 S {}
 E {}
-L 4 0 -30 0 30 {}
-L 4 -20 0 0 0 {}
-L 4 11.25 -21.25 20 -30 {}
-L 4 0 10 20 30 {}
-B 5 17.5 27.5 22.5 32.5 {name=C dir=inout pinnumber=3}
-B 5 -22.5 -2.5 -17.5 2.5 {name=B dir=in pinnumber=1}
-B 5 17.5 -32.5 22.5 -27.5 {name=E dir=inout pinnumber=2}
-P 4 4 0 -10 6.25 -26.25 16.25 -16.25 0 -10 {fill=true}
-T {m=@m} 22.5 11.25 0 0 0.2 0.2 {layer=13}
-T {@model} 22.5 -15 0 0 0.2 0.2 {}
-T {@spiceprefix@name} 22.5 -27.5 0 0 0.2 0.2 {}
+L 4 0 12.5 0 30 {}
+L 4 0 -30 0 -7.5 {}
+L 4 -15 -7.5 15 -7.5 {}
+B 4 -15 7.5 15 12.5 {}
+B 5 -2.5 -32.5 2.5 -27.5 {name=G dir=inout propag=1 pinnumber=2}
+B 5 -2.5 27.5 2.5 32.5 {name=B dir=inout propag=0 pinnumber=1}
+T {@m * @W / @L} 20 6.25 0 0 0.2 0.2 {layer=13}
+T {@model} 20 -11.25 0 0 0.2 0.2 {}
+T {@spiceprefix@name} 20 -28.75 0 0 0.2 0.2 {}
+T {NW} -25 15 0 0 0.2 0.2 { layer=4}

--- a/cells/xschem/symbols/cap_pmos_03v3_b.sym
+++ b/cells/xschem/symbols/cap_pmos_03v3_b.sym
@@ -16,24 +16,26 @@ v {xschem version=3.4.5 file_version=1.2
 
 }
 G {}
-K {type=vertical_pnp
-format="@spiceprefix@name @pinlist @model m=@m"
-template="name=Q1
-model=pnp_10p00x10p00
+K {type=moscap
+format="@spiceprefix@name @pinlist @model c_width=@W c_length=@L m=@m"
+template="name=C1
+W=1e-6
+L=1e-6
+model=cap_pmos_03v3_b
 spiceprefix=X
 m=1"
 }
 V {}
 S {}
 E {}
-L 4 0 -30 0 30 {}
-L 4 -20 0 0 0 {}
-L 4 11.25 -21.25 20 -30 {}
-L 4 0 10 20 30 {}
-B 5 17.5 27.5 22.5 32.5 {name=C dir=inout pinnumber=3}
-B 5 -22.5 -2.5 -17.5 2.5 {name=B dir=in pinnumber=1}
-B 5 17.5 -32.5 22.5 -27.5 {name=E dir=inout pinnumber=2}
-P 4 4 0 -10 6.25 -26.25 16.25 -16.25 0 -10 {fill=true}
-T {m=@m} 22.5 11.25 0 0 0.2 0.2 {layer=13}
-T {@model} 22.5 -15 0 0 0.2 0.2 {}
-T {@spiceprefix@name} 22.5 -27.5 0 0 0.2 0.2 {}
+L 4 0 -30 0 -10 {}
+L 4 -15 5 15 5 {}
+L 4 0 15 0 30 {}
+B 4 -15 -10 15 -5 {}
+B 5 -2.5 27.5 2.5 32.5 {name=G dir=inout propag=1 pinnumber=2}
+B 5 -2.5 -32.5 2.5 -27.5 {name=B dir=inout propag=0 pinnumber=1}
+A 4 0 10 5 90 360 {}
+T {@m * @W / @L} 20 6.25 0 0 0.2 0.2 {layer=13}
+T {@model} 20 -11.25 0 0 0.2 0.2 {}
+T {@spiceprefix@name} 20 -28.75 0 0 0.2 0.2 {}
+T {PW} -22.5 -25 0 0 0.2 0.2 { layer=4}

--- a/cells/xschem/symbols/cap_pmos_06v0_b.sym
+++ b/cells/xschem/symbols/cap_pmos_06v0_b.sym
@@ -16,24 +16,26 @@ v {xschem version=3.4.5 file_version=1.2
 
 }
 G {}
-K {type=vertical_pnp
-format="@spiceprefix@name @pinlist @model m=@m"
-template="name=Q1
-model=pnp_10p00x10p00
+K {type=moscap
+format="@spiceprefix@name @pinlist @model c_width=@W c_length=@L m=@m"
+template="name=C1
+W=1e-6
+L=1e-6
+model=cap_pmos_06v0_b
 spiceprefix=X
 m=1"
 }
 V {}
 S {}
 E {}
-L 4 0 -30 0 30 {}
-L 4 -20 0 0 0 {}
-L 4 11.25 -21.25 20 -30 {}
-L 4 0 10 20 30 {}
-B 5 17.5 27.5 22.5 32.5 {name=C dir=inout pinnumber=3}
-B 5 -22.5 -2.5 -17.5 2.5 {name=B dir=in pinnumber=1}
-B 5 17.5 -32.5 22.5 -27.5 {name=E dir=inout pinnumber=2}
-P 4 4 0 -10 6.25 -26.25 16.25 -16.25 0 -10 {fill=true}
-T {m=@m} 22.5 11.25 0 0 0.2 0.2 {layer=13}
-T {@model} 22.5 -15 0 0 0.2 0.2 {}
-T {@spiceprefix@name} 22.5 -27.5 0 0 0.2 0.2 {}
+L 4 0 -30 0 -12.5 {}
+L 4 -15 7.5 15 7.5 {}
+L 4 0 17.5 0 30 {}
+B 4 -15 -12.5 15 -7.5 {}
+B 5 -2.5 27.5 2.5 32.5 {name=G dir=inout propag=1 pinnumber=2}
+B 5 -2.5 -32.5 2.5 -27.5 {name=B dir=inout propag=0 pinnumber=1}
+A 4 0 12.5 5 90 360 {}
+T {@m * @W / @L} 20 6.25 0 0 0.2 0.2 {layer=13}
+T {@model} 20 -11.25 0 0 0.2 0.2 {}
+T {@spiceprefix@name} 20 -28.75 0 0 0.2 0.2 {}
+T {PW} -22.5 -27.5 0 0 0.2 0.2 { layer=4}

--- a/cells/xschem/symbols/diode_dw2ps.sym
+++ b/cells/xschem/symbols/diode_dw2ps.sym
@@ -16,24 +16,25 @@ v {xschem version=3.4.5 file_version=1.2
 
 }
 G {}
-K {type=vertical_pnp
-format="@spiceprefix@name @pinlist @model m=@m"
-template="name=Q1
-model=pnp_10p00x10p00
-spiceprefix=X
+K {type=diode
+format="@name @pinlist @model area='@r_w * @r_l ' pj='2*@r_w + 2*@r_l ' m=@m"
+template="name=D1
+model=diode_dw2ps
+r_w=1u
+r_l=1u
 m=1"
 }
 V {}
 S {}
 E {}
-L 4 0 -30 0 30 {}
-L 4 -20 0 0 0 {}
-L 4 11.25 -21.25 20 -30 {}
-L 4 0 10 20 30 {}
-B 5 17.5 27.5 22.5 32.5 {name=C dir=inout pinnumber=3}
-B 5 -22.5 -2.5 -17.5 2.5 {name=B dir=in pinnumber=1}
-B 5 17.5 -32.5 22.5 -27.5 {name=E dir=inout pinnumber=2}
-P 4 4 0 -10 6.25 -26.25 16.25 -16.25 0 -10 {fill=true}
-T {m=@m} 22.5 11.25 0 0 0.2 0.2 {layer=13}
-T {@model} 22.5 -15 0 0 0.2 0.2 {}
-T {@spiceprefix@name} 22.5 -27.5 0 0 0.2 0.2 {}
+L 4 0 5 0 30 {}
+L 4 0 -30 0 -5 {}
+L 4 -10 5 10 5 {}
+B 5 -2.5 -32.5 2.5 -27.5 {name=p dir=inout pinnumber=1 propag=1 goto=1}
+B 5 -2.5 27.5 2.5 32.5 {name=m dir=inout pinnumber=2 goto=0}
+P 4 4 0 5 -10 -5 10 -5 0 5 {fill=true}
+T {@name} 20 -28.75 0 0 0.2 0.2 {}
+T {W=@r_w} -15 -13.75 0 1 0.2 0.2 {layer=13}
+T {@model} 20 -16.25 0 0 0.2 0.2 {}
+T {L=@r_l} -15 -1.25 0 1 0.2 0.2 {layer=13}
+T {m=@m} -15 11.25 0 1 0.2 0.2 {layer=13}

--- a/cells/xschem/symbols/diode_nd2ps_06v0.sym
+++ b/cells/xschem/symbols/diode_nd2ps_06v0.sym
@@ -16,24 +16,25 @@ v {xschem version=3.4.5 file_version=1.2
 
 }
 G {}
-K {type=vertical_pnp
-format="@spiceprefix@name @pinlist @model m=@m"
-template="name=Q1
-model=pnp_10p00x10p00
-spiceprefix=X
+K {type=diode
+format="@name @pinlist @model area='@r_w * @r_l ' pj='2*@r_w + 2*@r_l ' m=@m"
+template="name=D1
+model=diode_nd2ps_06v0
+r_w=1u
+r_l=1u
 m=1"
 }
 V {}
 S {}
 E {}
-L 4 0 -30 0 30 {}
-L 4 -20 0 0 0 {}
-L 4 11.25 -21.25 20 -30 {}
-L 4 0 10 20 30 {}
-B 5 17.5 27.5 22.5 32.5 {name=C dir=inout pinnumber=3}
-B 5 -22.5 -2.5 -17.5 2.5 {name=B dir=in pinnumber=1}
-B 5 17.5 -32.5 22.5 -27.5 {name=E dir=inout pinnumber=2}
-P 4 4 0 -10 6.25 -26.25 16.25 -16.25 0 -10 {fill=true}
-T {m=@m} 22.5 11.25 0 0 0.2 0.2 {layer=13}
-T {@model} 22.5 -15 0 0 0.2 0.2 {}
-T {@spiceprefix@name} 22.5 -27.5 0 0 0.2 0.2 {}
+L 4 0 5 0 30 {}
+L 4 0 -30 0 -5 {}
+L 4 -10 5 10 5 {}
+B 5 -2.5 -32.5 2.5 -27.5 {name=p dir=inout pinnumber=1 propag=1 goto=1}
+B 5 -2.5 27.5 2.5 32.5 {name=m dir=inout pinnumber=2 goto=0}
+P 4 4 0 5 -10 -5 10 -5 0 5 {fill=true}
+T {@name} 20 -28.75 0 0 0.2 0.2 {}
+T {W=@r_w} -15 -13.75 0 1 0.2 0.2 {layer=13}
+T {@model} 20 -16.25 0 0 0.2 0.2 {}
+T {L=@r_l} -15 -1.25 0 1 0.2 0.2 {layer=13}
+T {m=@m} -15 11.25 0 1 0.2 0.2 {layer=13}

--- a/cells/xschem/symbols/diode_nw2ps_03v3.sym
+++ b/cells/xschem/symbols/diode_nw2ps_03v3.sym
@@ -16,24 +16,25 @@ v {xschem version=3.4.5 file_version=1.2
 
 }
 G {}
-K {type=vertical_pnp
-format="@spiceprefix@name @pinlist @model m=@m"
-template="name=Q1
-model=pnp_10p00x10p00
-spiceprefix=X
+K {type=diode
+format="@name @pinlist @model area='@r_w * @r_l ' pj='2*@r_w + 2*@r_l ' m=@m"
+template="name=D1
+model=diode_nw2ps_03v3
+r_w=1u
+r_l=1u
 m=1"
 }
 V {}
 S {}
 E {}
-L 4 0 -30 0 30 {}
-L 4 -20 0 0 0 {}
-L 4 11.25 -21.25 20 -30 {}
-L 4 0 10 20 30 {}
-B 5 17.5 27.5 22.5 32.5 {name=C dir=inout pinnumber=3}
-B 5 -22.5 -2.5 -17.5 2.5 {name=B dir=in pinnumber=1}
-B 5 17.5 -32.5 22.5 -27.5 {name=E dir=inout pinnumber=2}
-P 4 4 0 -10 6.25 -26.25 16.25 -16.25 0 -10 {fill=true}
-T {m=@m} 22.5 11.25 0 0 0.2 0.2 {layer=13}
-T {@model} 22.5 -15 0 0 0.2 0.2 {}
-T {@spiceprefix@name} 22.5 -27.5 0 0 0.2 0.2 {}
+L 4 0 5 0 30 {}
+L 4 0 -30 0 -5 {}
+L 4 -10 5 10 5 {}
+B 5 -2.5 -32.5 2.5 -27.5 {name=p dir=inout pinnumber=1 propag=1 goto=1}
+B 5 -2.5 27.5 2.5 32.5 {name=m dir=inout pinnumber=2 goto=0}
+P 4 4 0 5 -10 -5 10 -5 0 5 {fill=true}
+T {@name} 20 -28.75 0 0 0.2 0.2 {}
+T {W=@r_w} -15 -13.75 0 1 0.2 0.2 {layer=13}
+T {@model} 20 -16.25 0 0 0.2 0.2 {}
+T {L=@r_l} -15 -1.25 0 1 0.2 0.2 {layer=13}
+T {m=@m} -15 11.25 0 1 0.2 0.2 {layer=13}

--- a/cells/xschem/symbols/diode_nw2ps_06v0.sym
+++ b/cells/xschem/symbols/diode_nw2ps_06v0.sym
@@ -16,24 +16,25 @@ v {xschem version=3.4.5 file_version=1.2
 
 }
 G {}
-K {type=vertical_pnp
-format="@spiceprefix@name @pinlist @model m=@m"
-template="name=Q1
-model=pnp_10p00x10p00
-spiceprefix=X
+K {type=diode
+format="@name @pinlist @model area='@r_w * @r_l ' pj='2*@r_w + 2*@r_l ' m=@m"
+template="name=D1
+model=diode_nw2ps_06v0
+r_w=1u
+r_l=1u
 m=1"
 }
 V {}
 S {}
 E {}
-L 4 0 -30 0 30 {}
-L 4 -20 0 0 0 {}
-L 4 11.25 -21.25 20 -30 {}
-L 4 0 10 20 30 {}
-B 5 17.5 27.5 22.5 32.5 {name=C dir=inout pinnumber=3}
-B 5 -22.5 -2.5 -17.5 2.5 {name=B dir=in pinnumber=1}
-B 5 17.5 -32.5 22.5 -27.5 {name=E dir=inout pinnumber=2}
-P 4 4 0 -10 6.25 -26.25 16.25 -16.25 0 -10 {fill=true}
-T {m=@m} 22.5 11.25 0 0 0.2 0.2 {layer=13}
-T {@model} 22.5 -15 0 0 0.2 0.2 {}
-T {@spiceprefix@name} 22.5 -27.5 0 0 0.2 0.2 {}
+L 4 0 5 0 30 {}
+L 4 0 -30 0 -5 {}
+L 4 -10 5 10 5 {}
+B 5 -2.5 -32.5 2.5 -27.5 {name=p dir=inout pinnumber=1 propag=1 goto=1}
+B 5 -2.5 27.5 2.5 32.5 {name=m dir=inout pinnumber=2 goto=0}
+P 4 4 0 5 -10 -5 10 -5 0 5 {fill=true}
+T {@name} 20 -28.75 0 0 0.2 0.2 {}
+T {W=@r_w} -15 -13.75 0 1 0.2 0.2 {layer=13}
+T {@model} 20 -16.25 0 0 0.2 0.2 {}
+T {L=@r_l} -15 -1.25 0 1 0.2 0.2 {layer=13}
+T {m=@m} -15 11.25 0 1 0.2 0.2 {layer=13}

--- a/cells/xschem/symbols/diode_pd2nw_03v3.sym
+++ b/cells/xschem/symbols/diode_pd2nw_03v3.sym
@@ -16,24 +16,25 @@ v {xschem version=3.4.5 file_version=1.2
 
 }
 G {}
-K {type=vertical_pnp
-format="@spiceprefix@name @pinlist @model m=@m"
-template="name=Q1
-model=pnp_10p00x10p00
-spiceprefix=X
+K {type=diode
+format="@name @pinlist @model area='@r_w * @r_l ' pj='2*@r_w + 2*@r_l ' m=@m"
+template="name=D1
+model=diode_pd2nw_03v3
+r_w=1u
+r_l=1u
 m=1"
 }
 V {}
 S {}
 E {}
-L 4 0 -30 0 30 {}
-L 4 -20 0 0 0 {}
-L 4 11.25 -21.25 20 -30 {}
-L 4 0 10 20 30 {}
-B 5 17.5 27.5 22.5 32.5 {name=C dir=inout pinnumber=3}
-B 5 -22.5 -2.5 -17.5 2.5 {name=B dir=in pinnumber=1}
-B 5 17.5 -32.5 22.5 -27.5 {name=E dir=inout pinnumber=2}
-P 4 4 0 -10 6.25 -26.25 16.25 -16.25 0 -10 {fill=true}
-T {m=@m} 22.5 11.25 0 0 0.2 0.2 {layer=13}
-T {@model} 22.5 -15 0 0 0.2 0.2 {}
-T {@spiceprefix@name} 22.5 -27.5 0 0 0.2 0.2 {}
+L 4 0 5 0 30 {}
+L 4 0 -30 0 -5 {}
+L 4 -10 5 10 5 {}
+B 5 -2.5 -32.5 2.5 -27.5 {name=p dir=inout pinnumber=1 propag=1 goto=1}
+B 5 -2.5 27.5 2.5 32.5 {name=m dir=inout pinnumber=2 goto=0}
+P 4 4 0 5 -10 -5 10 -5 0 5 {fill=true}
+T {@name} 20 -28.75 0 0 0.2 0.2 {}
+T {W=@r_w} -15 -13.75 0 1 0.2 0.2 {layer=13}
+T {@model} 20 -16.25 0 0 0.2 0.2 {}
+T {L=@r_l} -15 -1.25 0 1 0.2 0.2 {layer=13}
+T {m=@m} -15 11.25 0 1 0.2 0.2 {layer=13}

--- a/cells/xschem/symbols/diode_pd2nw_06v0.sym
+++ b/cells/xschem/symbols/diode_pd2nw_06v0.sym
@@ -16,24 +16,25 @@ v {xschem version=3.4.5 file_version=1.2
 
 }
 G {}
-K {type=vertical_pnp
-format="@spiceprefix@name @pinlist @model m=@m"
-template="name=Q1
-model=pnp_10p00x10p00
-spiceprefix=X
+K {type=diode
+format="@name @pinlist @model area='@r_w * @r_l ' pj='2*@r_w + 2*@r_l ' m=@m"
+template="name=D1
+model=diode_pd2nw_06v0
+r_w=1u
+r_l=1u
 m=1"
 }
 V {}
 S {}
 E {}
-L 4 0 -30 0 30 {}
-L 4 -20 0 0 0 {}
-L 4 11.25 -21.25 20 -30 {}
-L 4 0 10 20 30 {}
-B 5 17.5 27.5 22.5 32.5 {name=C dir=inout pinnumber=3}
-B 5 -22.5 -2.5 -17.5 2.5 {name=B dir=in pinnumber=1}
-B 5 17.5 -32.5 22.5 -27.5 {name=E dir=inout pinnumber=2}
-P 4 4 0 -10 6.25 -26.25 16.25 -16.25 0 -10 {fill=true}
-T {m=@m} 22.5 11.25 0 0 0.2 0.2 {layer=13}
-T {@model} 22.5 -15 0 0 0.2 0.2 {}
-T {@spiceprefix@name} 22.5 -27.5 0 0 0.2 0.2 {}
+L 4 0 5 0 30 {}
+L 4 0 -30 0 -5 {}
+L 4 -10 5 10 5 {}
+B 5 -2.5 -32.5 2.5 -27.5 {name=p dir=inout pinnumber=1 propag=1 goto=1}
+B 5 -2.5 27.5 2.5 32.5 {name=m dir=inout pinnumber=2 goto=0}
+P 4 4 0 5 -10 -5 10 -5 0 5 {fill=true}
+T {@name} 20 -28.75 0 0 0.2 0.2 {}
+T {W=@r_w} -15 -13.75 0 1 0.2 0.2 {layer=13}
+T {@model} 20 -16.25 0 0 0.2 0.2 {}
+T {L=@r_l} -15 -1.25 0 1 0.2 0.2 {layer=13}
+T {m=@m} -15 11.25 0 1 0.2 0.2 {layer=13}

--- a/cells/xschem/symbols/nfet_06v0_dss.sym
+++ b/cells/xschem/symbols/nfet_06v0_dss.sym
@@ -1,0 +1,67 @@
+v {xschem version=3.4.5 file_version=1.2
+
+* Copyright 2022 GlobalFoundries PDK Authors
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*     https://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+
+}
+G {}
+K {type=nmos
+format="@spiceprefix@name @pinlist @model L=@L W=@W
++ nf=@nf ad=@ad as=@as pd=@pd ps=@ps
++ nrd=@nrd nrs=@nrs sa=@sa sb=@sb sd=@sd
++ m=@m"
+lvs_format="@name @pinlist @model L=@L W=@W nf=@nf m=@m"
+template="name=M1
+L=0.70u
+W=0.30u
+nf=1
+m=1
+ad=\\"'int((nf+1)/2) * W/nf * 0.18u'\\"
+pd=\\"'2*int((nf+1)/2) * (W/nf + 0.18u)'\\"
+as=\\"'int((nf+2)/2) * W/nf * 0.18u'\\"
+ps=\\"'2*int((nf+2)/2) * (W/nf + 0.18u)'\\"
+nrd=\\"'0.18u / W'\\" nrs=\\"'0.18u / W'\\"
+sa=0 sb=0 sd=0
+model=nfet_06v0_dss
+spiceprefix=X
+"
+}
+V {}
+S {}
+E {}
+L 4 7.5 -22.5 7.5 22.5 {}
+L 4 -20 0 -2.5 0 {}
+L 4 20 -30 20 -17.5 {}
+L 4 20 17.5 20 30 {}
+L 4 -2.5 -15 -2.5 15 {}
+L 4 7.5 17.5 15 17.5 {}
+B 5 17.5 -32.5 22.5 -27.5 {name=D dir=inout}
+B 5 -22.5 -2.5 -17.5 2.5 {name=G dir=in}
+B 5 17.5 27.5 22.5 32.5 {name=S dir=inout}
+B 5 19.921875 -0.078125 20.078125 0.078125 {name=B dir=in}
+P 4 4 15 15 20 17.5 15 20 15 15 {fill=true}
+P 4 4 20 -17.5 7.5 -17.5 7.5 -12.5 20 -17.5 {fill=true}
+P 5 4 20 -2.5 15 0 20 2.5 20 -2.5 {fill=true}
+T {S} 22.5 17.5 0 0 0.15 0.15 {layer=7}
+T {D} 22.5 -17.5 2 1 0.15 0.15 {layer=7}
+T {B} 20 -10 0 0 0.15 0.15 {layer=7}
+T {G} -10 -10 0 1 0.15 0.15 {layer=7}
+T {@model} 30 -8.75 2 1 0.2 0.2 {}
+T {@m x @W / @L} 31.25 13.75 0 0 0.2 0.2 { layer=13}
+T {nf=@nf} 31.25 1.25 0 0 0.2 0.2 { layer=13}
+T {tcleval(gm=[ngspice::get_node [subst -nocommand \{\\@m.$\{path\}@spiceprefix@name\\.msky130_fd_pr__@model\\[gm]\}]] )} 32.5 -7.5 0 0 0.15 0.15 {layer=15
+hide=true}
+T {tcleval(id=[ngspice::get_node [subst -nocommand \{i(\\@m.$\{path\}@spiceprefix@name\\.msky130_fd_pr__@model\\[id])\}]] )} 32.5 -30 0 0 0.15 0.15 {layer=15
+hide=true}
+T {@spiceprefix@name} 5 -30 0 1 0.2 0.2 {}

--- a/cells/xschem/symbols/nfet_10v0_asym.sym
+++ b/cells/xschem/symbols/nfet_10v0_asym.sym
@@ -1,0 +1,68 @@
+v {xschem version=3.4.5 file_version=1.2
+
+* Copyright 2022 GlobalFoundries PDK Authors
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*     https://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+
+}
+G {}
+K {type=nmos
+format="@spiceprefix@name @pinlist @model L=@L W=@W
++ nf=@nf ad=@ad as=@as pd=@pd ps=@ps
++ nrd=@nrd nrs=@nrs sa=@sa sb=@sb sd=@sd
++ m=@m"
+lvs_format="@name @pinlist @model L=@L W=@W nf=@nf m=@m"
+template="name=M1
+L=0.60u
+W=25u
+nf=1
+m=1
+ad=\\"'W * 1.48u'\\"
+pd=\\"'2 * (W + 1.48u)'\\"
+as=\\"'W * 0.48u'\\"
+ps=\\"'2 * (W + 0.48u)'\\"
+nrd=0 nrs=0
+sa=0 sb=0 sd=0
+model=nfet_10v0_asym
+spiceprefix=X
+"
+}
+V {}
+S {}
+E {}
+L 4 7.5 -22.5 7.5 22.5 {}
+L 4 20 -30 20 -17.5 {}
+L 4 20 17.5 20 30 {}
+L 4 7.5 -17.5 20 -17.5 {}
+L 4 7.5 17.5 15 17.5 {}
+L 4 -20 0 -7.5 -0 {}
+B 4 -7.5 -15 -2.5 15 {}
+B 5 17.5 -32.5 22.5 -27.5 {name=D dir=inout}
+B 5 -22.5 -2.5 -17.5 2.5 {name=G dir=in}
+B 5 17.5 27.5 22.5 32.5 {name=S dir=inout}
+B 5 19.921875 -0.078125 20.078125 0.078125 {name=B dir=in}
+P 4 4 15 15 20 17.5 15 20 15 15 {fill=true}
+P 5 4 20 -2.5 15 0 20 2.5 20 -2.5 {fill=true}
+T {S} 22.5 17.5 0 0 0.15 0.15 {layer=7}
+T {D} 22.5 -17.5 2 1 0.15 0.15 {layer=7}
+T {B} 20 -10 0 0 0.15 0.15 {layer=7}
+T {G} -10 -10 0 1 0.15 0.15 {layer=7}
+T {@model} 30 -8.75 2 1 0.2 0.2 {}
+T {@m x @W / @L} 31.25 13.75 0 0 0.2 0.2 { layer=13}
+T {nf=@nf} 31.25 1.25 0 0 0.2 0.2 { layer=13}
+T {tcleval(gm=[ngspice::get_node [subst -nocommand \{\\@m.$\{path\}@spiceprefix@name\\.msky130_fd_pr__@model\\[gm]\}]] )} 32.5 -7.5 0 0 0.15 0.15 {layer=15
+hide=true}
+T {tcleval(id=[ngspice::get_node [subst -nocommand \{i(\\@m.$\{path\}@spiceprefix@name\\.msky130_fd_pr__@model\\[id])\}]] )} 32.5 -30 0 0 0.15 0.15 {layer=15
+hide=true}
+T {@spiceprefix@name} 5 -30 0 1 0.2 0.2 {}
+T {10V} -16.25 19.375 0 0 0.2 0.2 { layer=4}

--- a/cells/xschem/symbols/npn_00p54x02p00.sym
+++ b/cells/xschem/symbols/npn_00p54x02p00.sym
@@ -16,10 +16,10 @@ v {xschem version=3.4.5 file_version=1.2
 
 }
 G {}
-K {type=vertical_pnp
+K {type=vertical_npn
 format="@spiceprefix@name @pinlist @model m=@m"
 template="name=Q1
-model=pnp_10p00x10p00
+model=npn_00p54x02p00
 spiceprefix=X
 m=1"
 }
@@ -28,12 +28,14 @@ S {}
 E {}
 L 4 0 -30 0 30 {}
 L 4 -20 0 0 0 {}
-L 4 11.25 -21.25 20 -30 {}
-L 4 0 10 20 30 {}
-B 5 17.5 27.5 22.5 32.5 {name=C dir=inout pinnumber=3}
+L 4 0 10 8.75 18.75 {}
+L 4 0 -10 20 -30 {}
+B 5 17.5 -32.5 22.5 -27.5 {name=C dir=inout pinnumber=3}
 B 5 -22.5 -2.5 -17.5 2.5 {name=B dir=in pinnumber=1}
-B 5 17.5 -32.5 22.5 -27.5 {name=E dir=inout pinnumber=2}
-P 4 4 0 -10 6.25 -26.25 16.25 -16.25 0 -10 {fill=true}
+B 5 17.5 27.5 22.5 32.5 {name=E dir=inout pinnumber=2}
+B 5 17.5 -2.5 22.5 2.5 {name=S dir=in pinnumber=1}
+P 4 4 20 30 13.75 13.75 3.75 23.75 20 30 {fill=true}
 T {m=@m} 22.5 11.25 0 0 0.2 0.2 {layer=13}
 T {@model} 22.5 -15 0 0 0.2 0.2 {}
+T {S} 10 -5 0 0 0.2 0.2 {}
 T {@spiceprefix@name} 22.5 -27.5 0 0 0.2 0.2 {}

--- a/cells/xschem/symbols/npn_00p54x04p00.sym
+++ b/cells/xschem/symbols/npn_00p54x04p00.sym
@@ -16,10 +16,10 @@ v {xschem version=3.4.5 file_version=1.2
 
 }
 G {}
-K {type=vertical_pnp
+K {type=vertical_npn
 format="@spiceprefix@name @pinlist @model m=@m"
 template="name=Q1
-model=pnp_10p00x10p00
+model=npn_00p54x04p00
 spiceprefix=X
 m=1"
 }
@@ -28,12 +28,14 @@ S {}
 E {}
 L 4 0 -30 0 30 {}
 L 4 -20 0 0 0 {}
-L 4 11.25 -21.25 20 -30 {}
-L 4 0 10 20 30 {}
-B 5 17.5 27.5 22.5 32.5 {name=C dir=inout pinnumber=3}
+L 4 0 10 8.75 18.75 {}
+L 4 0 -10 20 -30 {}
+B 5 17.5 -32.5 22.5 -27.5 {name=C dir=inout pinnumber=3}
 B 5 -22.5 -2.5 -17.5 2.5 {name=B dir=in pinnumber=1}
-B 5 17.5 -32.5 22.5 -27.5 {name=E dir=inout pinnumber=2}
-P 4 4 0 -10 6.25 -26.25 16.25 -16.25 0 -10 {fill=true}
+B 5 17.5 27.5 22.5 32.5 {name=E dir=inout pinnumber=2}
+B 5 17.5 -2.5 22.5 2.5 {name=S dir=in pinnumber=1}
+P 4 4 20 30 13.75 13.75 3.75 23.75 20 30 {fill=true}
 T {m=@m} 22.5 11.25 0 0 0.2 0.2 {layer=13}
 T {@model} 22.5 -15 0 0 0.2 0.2 {}
+T {S} 10 -5 0 0 0.2 0.2 {}
 T {@spiceprefix@name} 22.5 -27.5 0 0 0.2 0.2 {}

--- a/cells/xschem/symbols/npn_00p54x08p00.sym
+++ b/cells/xschem/symbols/npn_00p54x08p00.sym
@@ -16,10 +16,10 @@ v {xschem version=3.4.5 file_version=1.2
 
 }
 G {}
-K {type=vertical_pnp
+K {type=vertical_npn
 format="@spiceprefix@name @pinlist @model m=@m"
 template="name=Q1
-model=pnp_10p00x10p00
+model=npn_00p54x08p00
 spiceprefix=X
 m=1"
 }
@@ -28,12 +28,14 @@ S {}
 E {}
 L 4 0 -30 0 30 {}
 L 4 -20 0 0 0 {}
-L 4 11.25 -21.25 20 -30 {}
-L 4 0 10 20 30 {}
-B 5 17.5 27.5 22.5 32.5 {name=C dir=inout pinnumber=3}
+L 4 0 10 8.75 18.75 {}
+L 4 0 -10 20 -30 {}
+B 5 17.5 -32.5 22.5 -27.5 {name=C dir=inout pinnumber=3}
 B 5 -22.5 -2.5 -17.5 2.5 {name=B dir=in pinnumber=1}
-B 5 17.5 -32.5 22.5 -27.5 {name=E dir=inout pinnumber=2}
-P 4 4 0 -10 6.25 -26.25 16.25 -16.25 0 -10 {fill=true}
+B 5 17.5 27.5 22.5 32.5 {name=E dir=inout pinnumber=2}
+B 5 17.5 -2.5 22.5 2.5 {name=S dir=in pinnumber=1}
+P 4 4 20 30 13.75 13.75 3.75 23.75 20 30 {fill=true}
 T {m=@m} 22.5 11.25 0 0 0.2 0.2 {layer=13}
 T {@model} 22.5 -15 0 0 0.2 0.2 {}
+T {S} 10 -5 0 0 0.2 0.2 {}
 T {@spiceprefix@name} 22.5 -27.5 0 0 0.2 0.2 {}

--- a/cells/xschem/symbols/npn_00p54x16p00.sym
+++ b/cells/xschem/symbols/npn_00p54x16p00.sym
@@ -16,10 +16,10 @@ v {xschem version=3.4.5 file_version=1.2
 
 }
 G {}
-K {type=vertical_pnp
+K {type=vertical_npn
 format="@spiceprefix@name @pinlist @model m=@m"
 template="name=Q1
-model=pnp_10p00x10p00
+model=npn_00p54x16p00
 spiceprefix=X
 m=1"
 }
@@ -28,12 +28,14 @@ S {}
 E {}
 L 4 0 -30 0 30 {}
 L 4 -20 0 0 0 {}
-L 4 11.25 -21.25 20 -30 {}
-L 4 0 10 20 30 {}
-B 5 17.5 27.5 22.5 32.5 {name=C dir=inout pinnumber=3}
+L 4 0 10 8.75 18.75 {}
+L 4 0 -10 20 -30 {}
+B 5 17.5 -32.5 22.5 -27.5 {name=C dir=inout pinnumber=3}
 B 5 -22.5 -2.5 -17.5 2.5 {name=B dir=in pinnumber=1}
-B 5 17.5 -32.5 22.5 -27.5 {name=E dir=inout pinnumber=2}
-P 4 4 0 -10 6.25 -26.25 16.25 -16.25 0 -10 {fill=true}
+B 5 17.5 27.5 22.5 32.5 {name=E dir=inout pinnumber=2}
+B 5 17.5 -2.5 22.5 2.5 {name=S dir=in pinnumber=1}
+P 4 4 20 30 13.75 13.75 3.75 23.75 20 30 {fill=true}
 T {m=@m} 22.5 11.25 0 0 0.2 0.2 {layer=13}
 T {@model} 22.5 -15 0 0 0.2 0.2 {}
+T {S} 10 -5 0 0 0.2 0.2 {}
 T {@spiceprefix@name} 22.5 -27.5 0 0 0.2 0.2 {}

--- a/cells/xschem/symbols/npn_05p00x05p00.sym
+++ b/cells/xschem/symbols/npn_05p00x05p00.sym
@@ -16,10 +16,10 @@ v {xschem version=3.4.5 file_version=1.2
 
 }
 G {}
-K {type=vertical_pnp
+K {type=vertical_npn
 format="@spiceprefix@name @pinlist @model m=@m"
 template="name=Q1
-model=pnp_10p00x10p00
+model=npn_05p00x05p00
 spiceprefix=X
 m=1"
 }
@@ -28,12 +28,14 @@ S {}
 E {}
 L 4 0 -30 0 30 {}
 L 4 -20 0 0 0 {}
-L 4 11.25 -21.25 20 -30 {}
-L 4 0 10 20 30 {}
-B 5 17.5 27.5 22.5 32.5 {name=C dir=inout pinnumber=3}
+L 4 0 10 8.75 18.75 {}
+L 4 0 -10 20 -30 {}
+B 5 17.5 -32.5 22.5 -27.5 {name=C dir=inout pinnumber=3}
 B 5 -22.5 -2.5 -17.5 2.5 {name=B dir=in pinnumber=1}
-B 5 17.5 -32.5 22.5 -27.5 {name=E dir=inout pinnumber=2}
-P 4 4 0 -10 6.25 -26.25 16.25 -16.25 0 -10 {fill=true}
+B 5 17.5 27.5 22.5 32.5 {name=E dir=inout pinnumber=2}
+B 5 17.5 -2.5 22.5 2.5 {name=S dir=in pinnumber=1}
+P 4 4 20 30 13.75 13.75 3.75 23.75 20 30 {fill=true}
 T {m=@m} 22.5 11.25 0 0 0.2 0.2 {layer=13}
 T {@model} 22.5 -15 0 0 0.2 0.2 {}
+T {S} 10 -5 0 0 0.2 0.2 {}
 T {@spiceprefix@name} 22.5 -27.5 0 0 0.2 0.2 {}

--- a/cells/xschem/symbols/npolyf_s.sym
+++ b/cells/xschem/symbols/npolyf_s.sym
@@ -1,0 +1,48 @@
+v {xschem version=3.1.0 file_version=1.2
+
+* Copyright 2022 GlobalFoundries PDK Authors
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*     https://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+
+}
+G {}
+K {type=res
+format="@spiceprefix@name @pinlist @model r_width=@W r_length=@L m=@m"
+template="name=R1
+W=1e-6
+L=1e-6
+model=nplus_s
+spiceprefix=X
+m=1"
+}
+V {}
+S {}
+E {}
+L 4 0 20 0 30 {}
+L 4 0 20 7.5 17.5 {}
+L 4 -7.5 12.5 7.5 17.5 {}
+L 4 -7.5 12.5 7.5 7.5 {}
+L 4 -7.5 2.5 7.5 7.5 {}
+L 4 -7.5 2.5 7.5 -2.5 {}
+L 4 -7.5 -7.5 7.5 -2.5 {}
+L 4 -7.5 -7.5 7.5 -12.5 {}
+L 4 -7.5 -17.5 7.5 -12.5 {}
+L 4 -7.5 -17.5 0 -20 {}
+L 4 0 -30 0 -20 {}
+B 5 -2.5 27.5 2.5 32.5 {name=M dir=inout propag=1 pinnumber=2}
+B 5 -2.5 -32.5 2.5 -27.5 {name=P dir=inout propag=0 pinnumber=1}
+B 5 -22.5 -2.5 -17.5 2.5 {name=B dir=inout pinnumber=1}
+T {@m * @W / @L} 15 6.25 0 0 0.2 0.2 {layer=13}
+T {@model} 15 -11.25 0 0 0.2 0.2 {}
+T {B} -15 -12.5 0 1 0.15 0.15 {layer=7}
+T {@spiceprefix@name} 15 -28.75 0 0 0.2 0.2 {}

--- a/cells/xschem/symbols/pfet_06v0_dss.sym
+++ b/cells/xschem/symbols/pfet_06v0_dss.sym
@@ -1,0 +1,68 @@
+v {xschem version=3.4.5 file_version=1.2
+
+* Copyright 2022 GlobalFoundries PDK Authors
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*     https://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+
+}
+G {}
+K {type=pmos
+format="@spiceprefix@name @pinlist @model L=@L W=@W
++ nf=@nf ad=@ad as=@as pd=@pd ps=@ps
++ nrd=@nrd nrs=@nrs sa=@sa sb=@sb sd=@sd
++ m=@m"
+lvs_format="@name @pinlist @model L=@L W=@W nf=@nf m=@m"
+template="name=M1
+L=0.50u
+W=0.30u
+nf=1
+m=1
+ad=\\"'int((nf+1)/2) * W/nf * 0.18u'\\"
+pd=\\"'2*int((nf+1)/2) * (W/nf + 0.18u)'\\"
+as=\\"'int((nf+2)/2) * W/nf * 0.18u'\\"
+ps=\\"'2*int((nf+2)/2) * (W/nf + 0.18u)'\\"
+nrd=\\"'0.18u / W'\\" nrs=\\"'0.18u / W'\\"
+sa=0 sb=0 sd=0
+model=pfet_06v0_dss
+spiceprefix=X
+"
+}
+V {}
+S {}
+E {}
+L 4 7.5 -22.5 7.5 22.5 {}
+L 4 20 -30 20 -17.5 {}
+L 4 20 17.5 20 30 {}
+L 4 -2.5 -15 -2.5 15 {}
+L 4 12.5 -17.5 20 -17.5 {}
+L 4 -20 0 -12.5 0 {}
+B 5 17.5 27.5 22.5 32.5 {name=D dir=inout}
+B 5 -22.5 -2.5 -17.5 2.5 {name=G dir=in}
+B 5 17.5 -32.5 22.5 -27.5 {name=S dir=inout}
+B 5 19.921875 -0.078125 20.078125 0.078125 {name=B dir=in}
+A 4 -7.5 0 5 180 360 {}
+P 4 4 12.5 -20 7.5 -17.5 12.5 -15 12.5 -20 {fill=true}
+P 4 4 20 17.5 7.5 17.5 7.5 12.5 20 17.5 {fill=true}
+P 5 4 15 -2.5 20 0 15 2.5 15 -2.5 {fill=true}
+T {D} 22.5 17.5 0 0 0.15 0.15 {layer=7}
+T {S} 22.5 -17.5 2 1 0.15 0.15 {layer=7}
+T {B} 20 -10 0 0 0.15 0.15 {layer=7}
+T {G} -12.5 -12.5 0 1 0.15 0.15 {layer=7}
+T {@model} 30 -8.75 2 1 0.2 0.2 {}
+T {@m x @W / @L} 31.25 13.75 0 0 0.2 0.2 { layer=13}
+T {nf=@nf} 31.25 1.25 0 0 0.2 0.2 { layer=13}
+T {tcleval(gm=[ngspice::get_node [subst -nocommand \{\\@m.$\{path\}@spiceprefix@name\\.msky130_fd_pr__@model\\[gm]\}]] )} 32.5 -7.5 0 0 0.15 0.15 {layer=15
+hide=true}
+T {tcleval(id=[ngspice::get_node [subst -nocommand \{i(\\@m.$\{path\}@spiceprefix@name\\.msky130_fd_pr__@model\\[id])\}]] )} 32.5 -30 0 0 0.15 0.15 {layer=15
+hide=true}
+T {@spiceprefix@name} 5 -30 0 1 0.2 0.2 {}

--- a/cells/xschem/symbols/pfet_10v0_asym.sym
+++ b/cells/xschem/symbols/pfet_10v0_asym.sym
@@ -1,0 +1,69 @@
+v {xschem version=3.4.5 file_version=1.2
+
+* Copyright 2022 GlobalFoundries PDK Authors
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*     https://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+
+}
+G {}
+K {type=pmos
+format="@spiceprefix@name @pinlist @model L=@L W=@W
++ nf=@nf ad=@ad as=@as pd=@pd ps=@ps
++ nrd=@nrd nrs=@nrs sa=@sa sb=@sb sd=@sd
++ m=@m"
+lvs_format="@name @pinlist @model L=@L W=@W nf=@nf m=@m"
+template="name=M1
+L=0.6u
+W=25u
+nf=1
+m=1
+ad=\\"'W * 1.78u'\\"
+pd=\\"'2 * (W + 1.78u)'\\"
+as=\\"'W * 0.48u'\\"
+ps=\\"'2 * (W + 0.48u)'\\"
+nrd=0 nrs=0
+sa=0 sb=0 sd=0
+model=pfet_10v0_asym
+spiceprefix=X
+"
+}
+V {}
+S {}
+E {}
+L 4 7.5 -22.5 7.5 22.5 {}
+L 4 20 -30 20 -17.5 {}
+L 4 20 17.5 20 30 {}
+L 4 7.5 17.5 20 17.5 {}
+L 4 12.5 -17.5 20 -17.5 {}
+L 4 -20 -0 -17.5 0 {}
+B 4 -7.5 -15 -2.5 15 {}
+B 5 17.5 27.5 22.5 32.5 {name=D dir=inout}
+B 5 -22.5 -2.5 -17.5 2.5 {name=G dir=in}
+B 5 17.5 -32.5 22.5 -27.5 {name=S dir=inout}
+B 5 19.921875 -0.078125 20.078125 0.078125 {name=B dir=in}
+A 4 -12.5 0 5 180 360 {}
+P 4 4 12.5 -20 7.5 -17.5 12.5 -15 12.5 -20 {fill=true}
+P 5 4 15 -2.5 20 0 15 2.5 15 -2.5 {fill=true}
+T {D} 22.5 17.5 0 0 0.15 0.15 {layer=7}
+T {S} 22.5 -17.5 2 1 0.15 0.15 {layer=7}
+T {B} 20 -10 0 0 0.15 0.15 {layer=7}
+T {G} -12.5 -12.5 0 1 0.15 0.15 {layer=7}
+T {@model} 30 -8.75 2 1 0.2 0.2 {}
+T {@m x @W / @L} 31.25 13.75 0 0 0.2 0.2 { layer=13}
+T {nf=@nf} 31.25 1.25 0 0 0.2 0.2 { layer=13}
+T {tcleval(gm=[ngspice::get_node [subst -nocommand \{\\@m.$\{path\}@spiceprefix@name\\.msky130_fd_pr__@model\\[gm]\}]] )} 32.5 -7.5 0 0 0.15 0.15 {layer=15
+hide=true}
+T {tcleval(id=[ngspice::get_node [subst -nocommand \{i(\\@m.$\{path\}@spiceprefix@name\\.msky130_fd_pr__@model\\[id])\}]] )} 32.5 -30 0 0 0.15 0.15 {layer=15
+hide=true}
+T {@spiceprefix@name} 5 -30 0 1 0.2 0.2 {}
+T {10V} -18.75 16.875 0 0 0.2 0.2 { layer=4}

--- a/cells/xschem/symbols/pnp_05p00x00p42.sym
+++ b/cells/xschem/symbols/pnp_05p00x00p42.sym
@@ -19,7 +19,7 @@ G {}
 K {type=vertical_pnp
 format="@spiceprefix@name @pinlist @model m=@m"
 template="name=Q1
-model=pnp_10p00x10p00
+model=pnp_05p00x00p42
 spiceprefix=X
 m=1"
 }

--- a/cells/xschem/symbols/pnp_05p00x05p00.sym
+++ b/cells/xschem/symbols/pnp_05p00x05p00.sym
@@ -19,7 +19,7 @@ G {}
 K {type=vertical_pnp
 format="@spiceprefix@name @pinlist @model m=@m"
 template="name=Q1
-model=pnp_10p00x10p00
+model=pnp_05p00x05p00
 spiceprefix=X
 m=1"
 }

--- a/cells/xschem/symbols/pnp_10p00x00p42.sym
+++ b/cells/xschem/symbols/pnp_10p00x00p42.sym
@@ -19,7 +19,7 @@ G {}
 K {type=vertical_pnp
 format="@spiceprefix@name @pinlist @model m=@m"
 template="name=Q1
-model=pnp_10p00x10p00
+model=pnp_10p00x00p42
 spiceprefix=X
 m=1"
 }

--- a/cells/xschem/symbols/ppolyf_s.sym
+++ b/cells/xschem/symbols/ppolyf_s.sym
@@ -1,0 +1,48 @@
+v {xschem version=3.1.0 file_version=1.2
+
+* Copyright 2022 GlobalFoundries PDK Authors
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*     https://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+
+}
+G {}
+K {type=res
+format="@spiceprefix@name @pinlist @model r_width=@W r_length=@L m=@m"
+template="name=R1
+W=1e-6
+L=1e-6
+model=ppolyf_s
+spiceprefix=X
+m=1"
+}
+V {}
+S {}
+E {}
+L 4 0 20 0 30 {}
+L 4 0 20 7.5 17.5 {}
+L 4 -7.5 12.5 7.5 17.5 {}
+L 4 -7.5 12.5 7.5 7.5 {}
+L 4 -7.5 2.5 7.5 7.5 {}
+L 4 -7.5 2.5 7.5 -2.5 {}
+L 4 -7.5 -7.5 7.5 -2.5 {}
+L 4 -7.5 -7.5 7.5 -12.5 {}
+L 4 -7.5 -17.5 7.5 -12.5 {}
+L 4 -7.5 -17.5 0 -20 {}
+L 4 0 -30 0 -20 {}
+B 5 -2.5 27.5 2.5 32.5 {name=M dir=inout propag=1 pinnumber=2}
+B 5 -2.5 -32.5 2.5 -27.5 {name=P dir=inout propag=0 pinnumber=1}
+B 5 -22.5 -2.5 -17.5 2.5 {name=B dir=inout pinnumber=1}
+T {@m * @W / @L} 15 6.25 0 0 0.2 0.2 {layer=13}
+T {@model} 15 -11.25 0 0 0.2 0.2 {}
+T {B} -15 -12.5 0 1 0.15 0.15 {layer=7}
+T {@spiceprefix@name} 15 -28.75 0 0 0.2 0.2 {}

--- a/cells/xschem/symbols/ppolyf_u_1k.sym
+++ b/cells/xschem/symbols/ppolyf_u_1k.sym
@@ -1,0 +1,48 @@
+v {xschem version=3.1.0 file_version=1.2
+
+* Copyright 2022 GlobalFoundries PDK Authors
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*     https://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+
+}
+G {}
+K {type=res
+format="@spiceprefix@name @pinlist @model r_width=@W r_length=@L m=@m"
+template="name=R1
+W=1e-6
+L=1e-6
+model=ppolyf_u_1k
+spiceprefix=X
+m=1"
+}
+V {}
+S {}
+E {}
+L 4 0 20 0 30 {}
+L 4 0 20 7.5 17.5 {}
+L 4 -7.5 12.5 7.5 17.5 {}
+L 4 -7.5 12.5 7.5 7.5 {}
+L 4 -7.5 2.5 7.5 7.5 {}
+L 4 -7.5 2.5 7.5 -2.5 {}
+L 4 -7.5 -7.5 7.5 -2.5 {}
+L 4 -7.5 -7.5 7.5 -12.5 {}
+L 4 -7.5 -17.5 7.5 -12.5 {}
+L 4 -7.5 -17.5 0 -20 {}
+L 4 0 -30 0 -20 {}
+B 5 -2.5 27.5 2.5 32.5 {name=M dir=inout propag=1 pinnumber=2}
+B 5 -2.5 -32.5 2.5 -27.5 {name=P dir=inout propag=0 pinnumber=1}
+B 5 -22.5 -2.5 -17.5 2.5 {name=B dir=inout pinnumber=1}
+T {@m * @W / @L} 15 6.25 0 0 0.2 0.2 {layer=13}
+T {@model} 15 -11.25 0 0 0.2 0.2 {}
+T {B} -15 -12.5 0 1 0.15 0.15 {layer=7}
+T {@spiceprefix@name} 15 -28.75 0 0 0.2 0.2 {}

--- a/cells/xschem/symbols/ppolyf_u_1k_6p0.sym
+++ b/cells/xschem/symbols/ppolyf_u_1k_6p0.sym
@@ -1,0 +1,48 @@
+v {xschem version=3.1.0 file_version=1.2
+
+* Copyright 2022 GlobalFoundries PDK Authors
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*     https://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+
+}
+G {}
+K {type=res
+format="@spiceprefix@name @pinlist @model r_width=@W r_length=@L m=@m"
+template="name=R1
+W=1e-6
+L=1e-6
+model=ppolyf_u_1k_6p0
+spiceprefix=X
+m=1"
+}
+V {}
+S {}
+E {}
+L 4 0 20 0 30 {}
+L 4 0 20 7.5 17.5 {}
+L 4 -7.5 12.5 7.5 17.5 {}
+L 4 -7.5 12.5 7.5 7.5 {}
+L 4 -7.5 2.5 7.5 7.5 {}
+L 4 -7.5 2.5 7.5 -2.5 {}
+L 4 -7.5 -7.5 7.5 -2.5 {}
+L 4 -7.5 -7.5 7.5 -12.5 {}
+L 4 -7.5 -17.5 7.5 -12.5 {}
+L 4 -7.5 -17.5 0 -20 {}
+L 4 0 -30 0 -20 {}
+B 5 -2.5 27.5 2.5 32.5 {name=M dir=inout propag=1 pinnumber=2}
+B 5 -2.5 -32.5 2.5 -27.5 {name=P dir=inout propag=0 pinnumber=1}
+B 5 -22.5 -2.5 -17.5 2.5 {name=B dir=inout pinnumber=1}
+T {@m * @W / @L} 15 6.25 0 0 0.2 0.2 {layer=13}
+T {@model} 15 -11.25 0 0 0.2 0.2 {}
+T {B} -15 -12.5 0 1 0.15 0.15 {layer=7}
+T {@spiceprefix@name} 15 -28.75 0 0 0.2 0.2 {}

--- a/cells/xschem/symbols/ppolyf_u_2k.sym
+++ b/cells/xschem/symbols/ppolyf_u_2k.sym
@@ -1,0 +1,48 @@
+v {xschem version=3.1.0 file_version=1.2
+
+* Copyright 2022 GlobalFoundries PDK Authors
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*     https://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+
+}
+G {}
+K {type=res
+format="@spiceprefix@name @pinlist @model r_width=@W r_length=@L m=@m"
+template="name=R1
+W=1e-6
+L=1e-6
+model=ppolyf_u_2k
+spiceprefix=X
+m=1"
+}
+V {}
+S {}
+E {}
+L 4 0 20 0 30 {}
+L 4 0 20 7.5 17.5 {}
+L 4 -7.5 12.5 7.5 17.5 {}
+L 4 -7.5 12.5 7.5 7.5 {}
+L 4 -7.5 2.5 7.5 7.5 {}
+L 4 -7.5 2.5 7.5 -2.5 {}
+L 4 -7.5 -7.5 7.5 -2.5 {}
+L 4 -7.5 -7.5 7.5 -12.5 {}
+L 4 -7.5 -17.5 7.5 -12.5 {}
+L 4 -7.5 -17.5 0 -20 {}
+L 4 0 -30 0 -20 {}
+B 5 -2.5 27.5 2.5 32.5 {name=M dir=inout propag=1 pinnumber=2}
+B 5 -2.5 -32.5 2.5 -27.5 {name=P dir=inout propag=0 pinnumber=1}
+B 5 -22.5 -2.5 -17.5 2.5 {name=B dir=inout pinnumber=1}
+T {@m * @W / @L} 15 6.25 0 0 0.2 0.2 {layer=13}
+T {@model} 15 -11.25 0 0 0.2 0.2 {}
+T {B} -15 -12.5 0 1 0.15 0.15 {layer=7}
+T {@spiceprefix@name} 15 -28.75 0 0 0.2 0.2 {}

--- a/cells/xschem/symbols/ppolyf_u_2k_6p0.sym
+++ b/cells/xschem/symbols/ppolyf_u_2k_6p0.sym
@@ -1,0 +1,48 @@
+v {xschem version=3.1.0 file_version=1.2
+
+* Copyright 2022 GlobalFoundries PDK Authors
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*     https://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+
+}
+G {}
+K {type=res
+format="@spiceprefix@name @pinlist @model r_width=@W r_length=@L m=@m"
+template="name=R1
+W=1e-6
+L=1e-6
+model=ppolyf_u_2k_6p0
+spiceprefix=X
+m=1"
+}
+V {}
+S {}
+E {}
+L 4 0 20 0 30 {}
+L 4 0 20 7.5 17.5 {}
+L 4 -7.5 12.5 7.5 17.5 {}
+L 4 -7.5 12.5 7.5 7.5 {}
+L 4 -7.5 2.5 7.5 7.5 {}
+L 4 -7.5 2.5 7.5 -2.5 {}
+L 4 -7.5 -7.5 7.5 -2.5 {}
+L 4 -7.5 -7.5 7.5 -12.5 {}
+L 4 -7.5 -17.5 7.5 -12.5 {}
+L 4 -7.5 -17.5 0 -20 {}
+L 4 0 -30 0 -20 {}
+B 5 -2.5 27.5 2.5 32.5 {name=M dir=inout propag=1 pinnumber=2}
+B 5 -2.5 -32.5 2.5 -27.5 {name=P dir=inout propag=0 pinnumber=1}
+B 5 -22.5 -2.5 -17.5 2.5 {name=B dir=inout pinnumber=1}
+T {@m * @W / @L} 15 6.25 0 0 0.2 0.2 {layer=13}
+T {@model} 15 -11.25 0 0 0.2 0.2 {}
+T {B} -15 -12.5 0 1 0.15 0.15 {layer=7}
+T {@spiceprefix@name} 15 -28.75 0 0 0.2 0.2 {}

--- a/cells/xschem/symbols/ppolyf_u_3k.sym
+++ b/cells/xschem/symbols/ppolyf_u_3k.sym
@@ -1,0 +1,48 @@
+v {xschem version=3.1.0 file_version=1.2
+
+* Copyright 2022 GlobalFoundries PDK Authors
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*     https://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+
+}
+G {}
+K {type=res
+format="@spiceprefix@name @pinlist @model r_width=@W r_length=@L m=@m"
+template="name=R1
+W=1e-6
+L=1e-6
+model=ppolyf_u_3k
+spiceprefix=X
+m=1"
+}
+V {}
+S {}
+E {}
+L 4 0 20 0 30 {}
+L 4 0 20 7.5 17.5 {}
+L 4 -7.5 12.5 7.5 17.5 {}
+L 4 -7.5 12.5 7.5 7.5 {}
+L 4 -7.5 2.5 7.5 7.5 {}
+L 4 -7.5 2.5 7.5 -2.5 {}
+L 4 -7.5 -7.5 7.5 -2.5 {}
+L 4 -7.5 -7.5 7.5 -12.5 {}
+L 4 -7.5 -17.5 7.5 -12.5 {}
+L 4 -7.5 -17.5 0 -20 {}
+L 4 0 -30 0 -20 {}
+B 5 -2.5 27.5 2.5 32.5 {name=M dir=inout propag=1 pinnumber=2}
+B 5 -2.5 -32.5 2.5 -27.5 {name=P dir=inout propag=0 pinnumber=1}
+B 5 -22.5 -2.5 -17.5 2.5 {name=B dir=inout pinnumber=1}
+T {@m * @W / @L} 15 6.25 0 0 0.2 0.2 {layer=13}
+T {@model} 15 -11.25 0 0 0.2 0.2 {}
+T {B} -15 -12.5 0 1 0.15 0.15 {layer=7}
+T {@spiceprefix@name} 15 -28.75 0 0 0.2 0.2 {}

--- a/cells/xschem/symbols/rm2.sym
+++ b/cells/xschem/symbols/rm2.sym
@@ -16,24 +16,31 @@ v {xschem version=3.4.5 file_version=1.2
 
 }
 G {}
-K {type=vertical_pnp
-format="@spiceprefix@name @pinlist @model m=@m"
-template="name=Q1
-model=pnp_10p00x10p00
+K {type=res
+format="@spiceprefix@name @pinlist @model r_width=@W r_length=@L m=@m"
+template="name=R1
+W=0.6e-6
+L=0.6e-6
+model=rm2
 spiceprefix=X
 m=1"
 }
 V {}
 S {}
 E {}
-L 4 0 -30 0 30 {}
-L 4 -20 0 0 0 {}
-L 4 11.25 -21.25 20 -30 {}
-L 4 0 10 20 30 {}
-B 5 17.5 27.5 22.5 32.5 {name=C dir=inout pinnumber=3}
-B 5 -22.5 -2.5 -17.5 2.5 {name=B dir=in pinnumber=1}
-B 5 17.5 -32.5 22.5 -27.5 {name=E dir=inout pinnumber=2}
-P 4 4 0 -10 6.25 -26.25 16.25 -16.25 0 -10 {fill=true}
-T {m=@m} 22.5 11.25 0 0 0.2 0.2 {layer=13}
-T {@model} 22.5 -15 0 0 0.2 0.2 {}
-T {@spiceprefix@name} 22.5 -27.5 0 0 0.2 0.2 {}
+L 4 0 20 0 30 {}
+L 4 0 20 7.5 17.5 {}
+L 4 -7.5 12.5 7.5 17.5 {}
+L 4 -7.5 12.5 7.5 7.5 {}
+L 4 -7.5 2.5 7.5 7.5 {}
+L 4 -7.5 2.5 7.5 -2.5 {}
+L 4 -7.5 -7.5 7.5 -2.5 {}
+L 4 -7.5 -7.5 7.5 -12.5 {}
+L 4 -7.5 -17.5 7.5 -12.5 {}
+L 4 -7.5 -17.5 0 -20 {}
+L 4 0 -30 0 -20 {}
+B 5 -2.5 27.5 2.5 32.5 {name=M dir=inout propag=1 pinnumber=2}
+B 5 -2.5 -32.5 2.5 -27.5 {name=P dir=inout propag=0 pinnumber=1}
+T {@m * @W / @L} 15 6.25 0 0 0.2 0.2 {layer=13}
+T {@model} 15 -11.25 0 0 0.2 0.2 {}
+T {@spiceprefix@name} 15 -28.75 0 0 0.2 0.2 {}

--- a/cells/xschem/symbols/rm3.sym
+++ b/cells/xschem/symbols/rm3.sym
@@ -16,24 +16,31 @@ v {xschem version=3.4.5 file_version=1.2
 
 }
 G {}
-K {type=vertical_pnp
-format="@spiceprefix@name @pinlist @model m=@m"
-template="name=Q1
-model=pnp_10p00x10p00
+K {type=res
+format="@spiceprefix@name @pinlist @model r_width=@W r_length=@L m=@m"
+template="name=R1
+W=0.6e-6
+L=0.6e-6
+model=rm3
 spiceprefix=X
 m=1"
 }
 V {}
 S {}
 E {}
-L 4 0 -30 0 30 {}
-L 4 -20 0 0 0 {}
-L 4 11.25 -21.25 20 -30 {}
-L 4 0 10 20 30 {}
-B 5 17.5 27.5 22.5 32.5 {name=C dir=inout pinnumber=3}
-B 5 -22.5 -2.5 -17.5 2.5 {name=B dir=in pinnumber=1}
-B 5 17.5 -32.5 22.5 -27.5 {name=E dir=inout pinnumber=2}
-P 4 4 0 -10 6.25 -26.25 16.25 -16.25 0 -10 {fill=true}
-T {m=@m} 22.5 11.25 0 0 0.2 0.2 {layer=13}
-T {@model} 22.5 -15 0 0 0.2 0.2 {}
-T {@spiceprefix@name} 22.5 -27.5 0 0 0.2 0.2 {}
+L 4 0 20 0 30 {}
+L 4 0 20 7.5 17.5 {}
+L 4 -7.5 12.5 7.5 17.5 {}
+L 4 -7.5 12.5 7.5 7.5 {}
+L 4 -7.5 2.5 7.5 7.5 {}
+L 4 -7.5 2.5 7.5 -2.5 {}
+L 4 -7.5 -7.5 7.5 -2.5 {}
+L 4 -7.5 -7.5 7.5 -12.5 {}
+L 4 -7.5 -17.5 7.5 -12.5 {}
+L 4 -7.5 -17.5 0 -20 {}
+L 4 0 -30 0 -20 {}
+B 5 -2.5 27.5 2.5 32.5 {name=M dir=inout propag=1 pinnumber=2}
+B 5 -2.5 -32.5 2.5 -27.5 {name=P dir=inout propag=0 pinnumber=1}
+T {@m * @W / @L} 15 6.25 0 0 0.2 0.2 {layer=13}
+T {@model} 15 -11.25 0 0 0.2 0.2 {}
+T {@spiceprefix@name} 15 -28.75 0 0 0.2 0.2 {}

--- a/cells/xschem/symbols/sc_diode.sym
+++ b/cells/xschem/symbols/sc_diode.sym
@@ -16,24 +16,29 @@ v {xschem version=3.4.5 file_version=1.2
 
 }
 G {}
-K {type=vertical_pnp
-format="@spiceprefix@name @pinlist @model m=@m"
-template="name=Q1
-model=pnp_10p00x10p00
-spiceprefix=X
+K {type=diode
+format="@name @pinlist @model area='@r_w * @r_l ' pj='2*@r_w + 2*@r_l ' m=@m"
+template="name=D1
+model=sc_diode
+r_w=1u
+r_l=1u
 m=1"
 }
 V {}
 S {}
 E {}
-L 4 0 -30 0 30 {}
-L 4 -20 0 0 0 {}
-L 4 11.25 -21.25 20 -30 {}
-L 4 0 10 20 30 {}
-B 5 17.5 27.5 22.5 32.5 {name=C dir=inout pinnumber=3}
-B 5 -22.5 -2.5 -17.5 2.5 {name=B dir=in pinnumber=1}
-B 5 17.5 -32.5 22.5 -27.5 {name=E dir=inout pinnumber=2}
-P 4 4 0 -10 6.25 -26.25 16.25 -16.25 0 -10 {fill=true}
-T {m=@m} 22.5 11.25 0 0 0.2 0.2 {layer=13}
-T {@model} 22.5 -15 0 0 0.2 0.2 {}
-T {@spiceprefix@name} 22.5 -27.5 0 0 0.2 0.2 {}
+L 4 0 5 0 30 {}
+L 4 0 -30 0 -5 {}
+L 4 -15 5 15 5 {}
+L 4 15 0 15 5 {}
+L 4 10 0 15 0 {}
+L 4 -15 5 -15 10 {}
+L 4 -15 10 -10 10 {}
+B 5 -2.5 -32.5 2.5 -27.5 {name=p dir=inout pinnumber=1 propag=1 goto=1}
+B 5 -2.5 27.5 2.5 32.5 {name=m dir=inout pinnumber=2 goto=0}
+P 4 4 0 5 -10 -5 10 -5 0 5 {fill=true}
+T {@name} 20 -28.75 0 0 0.2 0.2 {}
+T {W=@r_w} -20 -13.75 0 1 0.2 0.2 {layer=13}
+T {@model} 20 -16.25 0 0 0.2 0.2 {}
+T {L=@r_l} -20 -1.25 0 1 0.2 0.2 {layer=13}
+T {m=@m} -20 11.25 0 1 0.2 0.2 {layer=13}

--- a/cells/xschem/tests/0_top.sch
+++ b/cells/xschem/tests/0_top.sch
@@ -1,4 +1,4 @@
-v {xschem version=3.1.0 file_version=1.2
+v {xschem version=3.4.5 file_version=1.2
 
 * Copyright 2022 GlobalFoundries PDK Authors
 *
@@ -20,37 +20,41 @@ K {}
 V {}
 S {}
 E {}
-L 7 360 -730 360 -60 {}
-L 7 700 -730 700 -60 {}
-L 7 1040 -730 1040 -60 {}
-L 7 1380 -730 1380 -60 {}
-L 7 1720 -730 1720 -60 {}
-L 7 20 -730 20 -60 {}
-T {MOSFETS} 40 -710 0 0 0.8 0.8 {}
-T {CAPACITORS} 380 -710 0 0 0.8 0.8 {}
-T {BJTs} 730 -710 0 0 0.8 0.8 {}
-T {DIODES} 1060 -710 0 0 0.8 0.8 {}
-T {RESISTORS} 1410 -710 0 0 0.8 0.8 {}
+L 7 360 -990 360 -60 {}
+L 7 700 -990 700 -60 {}
+L 7 1040 -990 1040 -60 {}
+L 7 1380 -990 1380 -60 {}
+L 7 1720 -990 1720 -60 {}
+L 7 20 -990 20 -60 {}
+T {MOSFETS} 40 -970 0 0 0.8 0.8 {}
+T {CAPACITORS} 380 -970 0 0 0.8 0.8 {}
+T {BJTs} 730 -970 0 0 0.8 0.8 {}
+T {DIODES} 1060 -970 0 0 0.8 0.8 {}
+T {RESISTORS} 1410 -970 0 0 0.8 0.8 {}
+T {Deprecated symbol:
+cap_mim_2p0fF.sym
+equivalent to
+cap_mim_2f0fF.sym} 430 -890 0 0 0.4 0.4 {}
 C {test_nfet_03v3.sym} 190 -460 0 0 {name=x1}
 C {test_nfet_03v3_dss.sym} 190 -410 0 0 {name=x2}
 C {test_pfet_03v3.sym} 190 -360 0 0 {name=x3}
 C {test_pfet_03v3_dss.sym} 190 -310 0 0 {name=x4}
 C {devices/title.sym} 160 -30 0 0 {name=l5 author="GlobalFoundries PDK Authors"}
-C {devices/launcher.sym} 90 -840 0 0 {name=h1
+C {devices/launcher.sym} 90 -1100 0 0 {name=h1
 descr="List of devices (Google docs)"
 url="https://docs.google.com/spreadsheets/d/1xxxg_VzZWJ1NNysSMcOVzyUin7M2dvtb_E7X-5WQKJ0/edit#gid=1056368354"}
 C {test_nfet_06v0.sym} 190 -260 0 0 {name=x5}
 C {test_pfet_06v0.sym} 190 -160 0 0 {name=x6}
 C {test_nfet_06v0_nvt.sym} 190 -110 0 0 {name=x7}
-C {test_nplus_u.sym} 1550 -360 0 0 {name=x8}
-C {devices/launcher.sym} 90 -790 0 0 {name=h2
+C {test_nplus_u.sym} 1550 -660 0 0 {name=x8}
+C {devices/launcher.sym} 90 -1050 0 0 {name=h2
 descr="Gitlab"
 url="https://gitlab.com"}
 C {test_cap_nmos_03v3.sym} 530 -260 0 0 {name=x9}
 C {test_cap_pmos_03v3.sym} 530 -210 0 0 {name=x10}
-C {test_pplus_u.sym} 1550 -310 0 0 {name=x11}
+C {test_pplus_u.sym} 1550 -610 0 0 {name=x11}
 C {test_npn_10p00x10p00.sym} 870 -110 0 0 {name=x12}
-C {test_pnp_10p00x10p00.sym} 870 -160 0 0 {name=x13}
+C {test_pnp_10p00x10p00.sym} 870 -410 0 0 {name=x13}
 C {test_diode_nd2ps_03v3.sym} 1210 -110 0 0 {name=x14}
 C {test_nwell.sym} 1550 -110 0 0 {name=x15}
 C {test_npolyf_u.sym} 1550 -210 0 0 {name=x16}
@@ -58,6 +62,47 @@ C {test_ppolyf_u.sym} 1550 -160 0 0 {name=x17}
 C {test_cap_nmos_06v0.sym} 530 -110 0 0 {name=x18}
 C {test_cap_pmos_06v0.sym} 530 -160 0 0 {name=x20}
 C {test_diode_pw2dw.sym} 1210 -160 0 0 {name=x21}
-C {test_rm1.sym} 1550 -260 0 0 {name=x22}
-C {test_cap_mim_2f0fF.sym} 530 -310 0 0 {name=x23}
+C {test_rm1.sym} 1550 -710 0 0 {name=x22}
+C {test_cap_mim_2f0fF.sym} 530 -510 0 0 {name=x23}
 C {test_nfet_05v0.sym} 190 -210 0 0 {name=x19}
+C {test_rm2.sym} 1550 -760 0 0 {name=x24}
+C {test_rm3.sym} 1550 -810 0 0 {name=x25}
+C {test_cap_nmos_03v3_b.sym} 530 -310 0 0 {name=x26}
+C {test_cap_pmos_03v3_b.sym} 530 -360 0 0 {name=x27}
+C {test_cap_pmos_06v0_b.sym} 530 -410 0 0 {name=x28}
+C {test_cap_nmos_06v0_b.sym} 530 -460 0 0 {name=x29}
+C {test_ppolyf_s.sym} 1550 -560 0 0 {name=x30}
+C {test_npolyf_s.sym} 1550 -510 0 0 {name=x31}
+C {test_ppolyf_u_1k_6p0.sym} 1550 -460 0 0 {name=x33}
+C {test_ppolyf_u_2k_6p0.sym} 1550 -410 0 0 {name=x34}
+C {test_ppolyf_u_1k.sym} 1550 -360 0 0 {name=x35}
+C {test_ppolyf_u_2k.sym} 1550 -310 0 0 {name=x36}
+C {test_ppolyf_u_3k.sym} 1550 -260 0 0 {name=x37}
+C {test_cap_mim_1f5fF.sym} 530 -560 0 0 {name=x32}
+C {test_cap_mim_1f0fF.sym} 530 -610 0 0 {name=x38}
+C {test_cap_mim_analog.sym} 530 -660 0 0 {name=x39}
+C {test_npn_05p00x05p00.sym} 870 -160 0 0 {name=x40}
+C {test_npn_00p54x16p00.sym} 870 -210 0 0 {name=x41}
+C {test_npn_00p54x08p00.sym} 870 -260 0 0 {name=x42}
+C {test_npn_00p54x04p00.sym} 870 -310 0 0 {name=x43}
+C {test_npn_00p54x02p00.sym} 870 -360 0 0 {name=x44}
+C {test_pnp_05p00x05p00.sym} 870 -460 0 0 {name=x45}
+C {test_pnp_05p00x00p42.sym} 870 -510 0 0 {name=x46}
+C {test_pnp_10p00x00p42.sym} 870 -560 0 0 {name=x47}
+C {test_diode_pd2nw_03v3.sym} 1210 -210 0 0 {name=x48}
+C {test_diode_nd2ps_06v0.sym} 1210 -260 0 0 {name=x49}
+C {test_diode_pd2nw_06v0.sym} 1210 -310 0 0 {name=x50}
+C {test_diode_nw2ps_03v3.sym} 1210 -360 0 0 {name=x51}
+C {test_diode_nw2ps_06v0.sym} 1210 -410 0 0 {name=x52}
+C {test_diode_dw2ps.sym} 1210 -460 0 0 {name=x53}
+C {test_sc_diode.sym} 1210 -510 0 0 {name=x54}
+C {test_nfet_06v0_dss.sym} 190 -510 0 0 {name=x55}
+C {test_pfet_06v0_dss.sym} 190 -560 0 0 {name=x56}
+C {test_nfet_10v0_asym.sym} 190 -610 0 0 {name=x57}
+C {test_pfet_10v0_asym.sym} 190 -660 0 0 {name=x58}
+C {symbols/cap_mim_2p0fF.sym} 520 -740 0 0 {name=C1
+W=1e-6
+L=1e-6
+model=cap_mim_2f0fF
+spiceprefix=X
+m=1}

--- a/cells/xschem/tests/test_cap_mim_1f0fF.sch
+++ b/cells/xschem/tests/test_cap_mim_1f0fF.sch
@@ -20,33 +20,36 @@ K {}
 V {}
 S {}
 E {}
-B 2 580 -540 1170 -80 {flags=graph
-y1=-0.0067
-y2=0
-ypos1=0
-ypos2=2
-divy=5
-subdivy=1
-unity=m
-x1=0
-x2=3.3
-divx=5
-subdivx=1
-node=i(vp)
-color=4
-
-unitx=1
-dataset=-1}
-B 2 580 -1000 1170 -540 {flags=graph
-y1=-0
-y2=500
+B 2 750 -540 1340 -80 {flags=graph
+y1=0
+y2=3.3
 ypos1=0
 ypos2=2
 divy=5
 subdivy=1
 unity=1
 x1=0
-x2=3.3
+x2=2e-07
+divx=5
+subdivx=1
+
+
+
+unitx=1
+dataset=-1
+color="4 7"
+node="in
+p"}
+B 2 750 -1000 1340 -540 {flags=graph
+y1=-2.2e-13
+y2=0
+ypos1=0
+ypos2=2
+divy=5
+subdivy=1
+unity=1
+x1=0
+x2=2e-07
 divx=5
 subdivx=1
 
@@ -55,47 +58,60 @@ subdivx=1
 unitx=1
 dataset=-1
 color=4
-node="\\"resistance; p i(vp) / -1 *\\""}
-N 130 -490 130 -440 {
+node="\\"Capac; i(v1) p deriv() /\\""}
+N 230 -470 230 -420 {
 lab=P}
-N 80 -410 110 -410 {
-lab=B}
-N 130 -380 130 -310 {
-lab=M}
-C {devices/code_shown.sym} 20 -160 0 0 {name=MODELS only_toplevel=true
+N 230 -360 230 -290 {
+lab=GND}
+N 50 -490 230 -490 {
+lab=P}
+N 230 -490 230 -470 {
+lab=P}
+N 50 -330 50 -310 {
+lab=GND}
+N 50 -310 230 -310 {
+lab=GND}
+N 50 -430 50 -390 {
+lab=IN}
+C {devices/code_shown.sym} 30 -240 0 0 {name=MODELS only_toplevel=true
 format="tcleval( @value )"
 value="
 .include $::180MCU_MODELS/design.ngspice
 .lib $::180MCU_MODELS/sm141064.ngspice typical
+.lib $::180MCU_MODELS/sm141064.ngspice cap_mim
 .lib $::180MCU_MODELS/sm141064.ngspice res_typical
+.lib $::180MCU_MODELS/sm141064.ngspice moscap_typical
+.lib $::180MCU_MODELS/sm141064.ngspice mimcap_typical
 * .lib $::180MCU_MODELS/sm141064.ngspice res_statistical
 "}
-C {devices/lab_pin.sym} 130 -490 0 0 {name=l2 sig_type=std_logic lab=P}
-C {devices/lab_pin.sym} 130 -310 0 0 {name=l3 sig_type=std_logic lab=M}
-C {devices/lab_pin.sym} 80 -410 0 0 {name=l4 sig_type=std_logic lab=B}
-C {devices/code_shown.sym} 300 -450 0 0 {name=NGSPICE only_toplevel=true
+C {devices/code_shown.sym} 390 -450 0 0 {name=NGSPICE only_toplevel=true
 value="
-vp p 0 0
-vm m 0 0
-vb b 0 3.3
-
 .control
 save all
-dc vp 0 3.3 0.01
-write test_ppolyf_u.raw
+tran 0.1n 200n
+write test_cap_mim_1f0fF.raw
 .endc
 "}
 C {devices/title.sym} 160 -30 0 0 {name=l5 author="GlobalFoundries PDK Authors"}
-C {devices/launcher.sym} 65 -645 0 0 {name=h1
+C {devices/launcher.sym} 185 -635 0 0 {name=h1
 descr="Click left mouse button here with control key
 pressed to load/unload waveforms in graph."
 tclcommand="
 xschem raw_read $netlist_dir/[file tail [file rootname [xschem get current_name]]].raw
 "
 }
-C {symbols/ppolyf_u.sym} 130 -410 0 0 {name=R1
-W=1e-6
-L=1e-6
-model=ppolyf_u
+C {symbols/cap_mim_1f0fF.sym} 230 -390 0 0 {name=C1
+W=10e-6
+L=10e-6
+model=cap_mim_1f0fF
 spiceprefix=X
 m=1}
+C {devices/vsource.sym} 50 -360 0 0 {name=V1 value="pwl 0 0 200n 3.3"}
+C {devices/res.sym} 50 -460 0 0 {name=R2
+value=100k
+footprint=1206
+device=resistor
+m=1}
+C {devices/lab_pin.sym} 50 -410 0 0 {name=l1 sig_type=std_logic lab=IN}
+C {devices/gnd.sym} 230 -290 0 0 {name=l2 lab=GND}
+C {devices/lab_pin.sym} 230 -490 0 1 {name=l3 sig_type=std_logic lab=P}

--- a/cells/xschem/tests/test_cap_mim_1f0fF.sym
+++ b/cells/xschem/tests/test_cap_mim_1f0fF.sym
@@ -1,4 +1,4 @@
-v {xschem version=3.4.5 file_version=1.2
+v {xschem version=3.0.0 file_version=1.2
 
 * Copyright 2022 GlobalFoundries PDK Authors
 *
@@ -15,26 +15,13 @@ v {xschem version=3.4.5 file_version=1.2
 * limitations under the License.
 
 }
-G {}
-K {type=moscap
-format="@spiceprefix@name @pinlist @model c_width=@W c_length=@L m=@m"
-template="name=C1
-W=1e-6
-L=1e-6
-model=cap_nmos_03v3
-spiceprefix=X
-m=1"
+K {type=subcircuit
+format="@name @pinlist @symname"
+template="name=x1"
 }
-V {}
-S {}
-E {}
-L 4 0 10 0 30 {}
-L 4 0 -30 0 -5 {}
-L 4 -15 -5 15 -5 {}
-B 4 -15 5 15 10 {}
-B 5 -2.5 -32.5 2.5 -27.5 {name=G dir=inout propag=1 pinnumber=2}
-B 5 -2.5 27.5 2.5 32.5 {name=B dir=inout propag=0 pinnumber=1}
-T {@m * @W / @L} 20 6.25 0 0 0.2 0.2 {layer=13}
-T {@model} 20 -11.25 0 0 0.2 0.2 {}
-T {@spiceprefix@name} 20 -28.75 0 0 0.2 0.2 {}
-T {PW} -25 12.5 0 0 0.2 0.2 { layer=4}
+T {@symname} -76.5 -6 0 0 0.3 0.3 {}
+T {@name} 135 -22 0 0 0.2 0.2 {}
+L 4 -130 -10 130 -10 {}
+L 4 -130 10 130 10 {}
+L 4 -130 -10 -130 10 {}
+L 4 130 -10 130 10 {}

--- a/cells/xschem/tests/test_cap_mim_1f5fF.sch
+++ b/cells/xschem/tests/test_cap_mim_1f5fF.sch
@@ -20,33 +20,36 @@ K {}
 V {}
 S {}
 E {}
-B 2 580 -540 1170 -80 {flags=graph
-y1=-0.0067
-y2=0
-ypos1=0
-ypos2=2
-divy=5
-subdivy=1
-unity=m
-x1=0
-x2=3.3
-divx=5
-subdivx=1
-node=i(vp)
-color=4
-
-unitx=1
-dataset=-1}
-B 2 580 -1000 1170 -540 {flags=graph
-y1=-0
-y2=500
+B 2 750 -540 1340 -80 {flags=graph
+y1=0
+y2=3.3
 ypos1=0
 ypos2=2
 divy=5
 subdivy=1
 unity=1
 x1=0
-x2=3.3
+x2=2e-07
+divx=5
+subdivx=1
+
+
+
+unitx=1
+dataset=-1
+color="4 7"
+node="in
+p"}
+B 2 750 -1000 1340 -540 {flags=graph
+y1=-2.2e-13
+y2=0
+ypos1=0
+ypos2=2
+divy=5
+subdivy=1
+unity=1
+x1=0
+x2=2e-07
 divx=5
 subdivx=1
 
@@ -55,47 +58,60 @@ subdivx=1
 unitx=1
 dataset=-1
 color=4
-node="\\"resistance; p i(vp) / -1 *\\""}
-N 130 -490 130 -440 {
+node="\\"Capac; i(v1) p deriv() /\\""}
+N 230 -470 230 -420 {
 lab=P}
-N 80 -410 110 -410 {
-lab=B}
-N 130 -380 130 -310 {
-lab=M}
-C {devices/code_shown.sym} 20 -160 0 0 {name=MODELS only_toplevel=true
+N 230 -360 230 -290 {
+lab=GND}
+N 50 -490 230 -490 {
+lab=P}
+N 230 -490 230 -470 {
+lab=P}
+N 50 -330 50 -310 {
+lab=GND}
+N 50 -310 230 -310 {
+lab=GND}
+N 50 -430 50 -390 {
+lab=IN}
+C {devices/code_shown.sym} 30 -240 0 0 {name=MODELS only_toplevel=true
 format="tcleval( @value )"
 value="
 .include $::180MCU_MODELS/design.ngspice
 .lib $::180MCU_MODELS/sm141064.ngspice typical
+.lib $::180MCU_MODELS/sm141064.ngspice cap_mim
 .lib $::180MCU_MODELS/sm141064.ngspice res_typical
+.lib $::180MCU_MODELS/sm141064.ngspice moscap_typical
+.lib $::180MCU_MODELS/sm141064.ngspice mimcap_typical
 * .lib $::180MCU_MODELS/sm141064.ngspice res_statistical
 "}
-C {devices/lab_pin.sym} 130 -490 0 0 {name=l2 sig_type=std_logic lab=P}
-C {devices/lab_pin.sym} 130 -310 0 0 {name=l3 sig_type=std_logic lab=M}
-C {devices/lab_pin.sym} 80 -410 0 0 {name=l4 sig_type=std_logic lab=B}
-C {devices/code_shown.sym} 300 -450 0 0 {name=NGSPICE only_toplevel=true
+C {devices/code_shown.sym} 390 -450 0 0 {name=NGSPICE only_toplevel=true
 value="
-vp p 0 0
-vm m 0 0
-vb b 0 3.3
-
 .control
 save all
-dc vp 0 3.3 0.01
-write test_ppolyf_u.raw
+tran 0.1n 200n
+write test_cap_mim_1f5fF.raw
 .endc
 "}
 C {devices/title.sym} 160 -30 0 0 {name=l5 author="GlobalFoundries PDK Authors"}
-C {devices/launcher.sym} 65 -645 0 0 {name=h1
+C {devices/launcher.sym} 185 -635 0 0 {name=h1
 descr="Click left mouse button here with control key
 pressed to load/unload waveforms in graph."
 tclcommand="
 xschem raw_read $netlist_dir/[file tail [file rootname [xschem get current_name]]].raw
 "
 }
-C {symbols/ppolyf_u.sym} 130 -410 0 0 {name=R1
-W=1e-6
-L=1e-6
-model=ppolyf_u
+C {symbols/cap_mim_1f5fF.sym} 230 -390 0 0 {name=C1
+W=10e-6
+L=10e-6
+model=cap_mim_1f5fF
 spiceprefix=X
 m=1}
+C {devices/vsource.sym} 50 -360 0 0 {name=V1 value="pwl 0 0 200n 3.3"}
+C {devices/res.sym} 50 -460 0 0 {name=R2
+value=100k
+footprint=1206
+device=resistor
+m=1}
+C {devices/lab_pin.sym} 50 -410 0 0 {name=l1 sig_type=std_logic lab=IN}
+C {devices/gnd.sym} 230 -290 0 0 {name=l2 lab=GND}
+C {devices/lab_pin.sym} 230 -490 0 1 {name=l3 sig_type=std_logic lab=P}

--- a/cells/xschem/tests/test_cap_mim_1f5fF.sym
+++ b/cells/xschem/tests/test_cap_mim_1f5fF.sym
@@ -1,4 +1,4 @@
-v {xschem version=3.4.5 file_version=1.2
+v {xschem version=3.0.0 file_version=1.2
 
 * Copyright 2022 GlobalFoundries PDK Authors
 *
@@ -15,26 +15,13 @@ v {xschem version=3.4.5 file_version=1.2
 * limitations under the License.
 
 }
-G {}
-K {type=moscap
-format="@spiceprefix@name @pinlist @model c_width=@W c_length=@L m=@m"
-template="name=C1
-W=1e-6
-L=1e-6
-model=cap_nmos_03v3
-spiceprefix=X
-m=1"
+K {type=subcircuit
+format="@name @pinlist @symname"
+template="name=x1"
 }
-V {}
-S {}
-E {}
-L 4 0 10 0 30 {}
-L 4 0 -30 0 -5 {}
-L 4 -15 -5 15 -5 {}
-B 4 -15 5 15 10 {}
-B 5 -2.5 -32.5 2.5 -27.5 {name=G dir=inout propag=1 pinnumber=2}
-B 5 -2.5 27.5 2.5 32.5 {name=B dir=inout propag=0 pinnumber=1}
-T {@m * @W / @L} 20 6.25 0 0 0.2 0.2 {layer=13}
-T {@model} 20 -11.25 0 0 0.2 0.2 {}
-T {@spiceprefix@name} 20 -28.75 0 0 0.2 0.2 {}
-T {PW} -25 12.5 0 0 0.2 0.2 { layer=4}
+T {@symname} -76.5 -6 0 0 0.3 0.3 {}
+T {@name} 135 -22 0 0 0.2 0.2 {}
+L 4 -130 -10 130 -10 {}
+L 4 -130 10 130 10 {}
+L 4 -130 -10 -130 10 {}
+L 4 130 -10 130 10 {}

--- a/cells/xschem/tests/test_cap_mim_2f0fF.sch
+++ b/cells/xschem/tests/test_cap_mim_2f0fF.sch
@@ -1,4 +1,4 @@
-v {xschem version=3.1.0 file_version=1.2
+v {xschem version=3.4.5 file_version=1.2
 
 * Copyright 2022 GlobalFoundries PDK Authors
 *
@@ -100,7 +100,7 @@ tclcommand="
 xschem raw_read $netlist_dir/[file tail [file rootname [xschem get current_name]]].raw
 "
 }
-C {symbols/cap_mim_2p0fF.sym} 230 -390 0 0 {name=C1
+C {symbols/cap_mim_2f0fF.sym} 230 -390 0 0 {name=C1
 W=10e-6
 L=10e-6
 model=cap_mim_2f0fF

--- a/cells/xschem/tests/test_cap_mim_analog.sch
+++ b/cells/xschem/tests/test_cap_mim_analog.sch
@@ -20,33 +20,36 @@ K {}
 V {}
 S {}
 E {}
-B 2 580 -540 1170 -80 {flags=graph
-y1=-0.0067
-y2=0
-ypos1=0
-ypos2=2
-divy=5
-subdivy=1
-unity=m
-x1=0
-x2=3.3
-divx=5
-subdivx=1
-node=i(vp)
-color=4
-
-unitx=1
-dataset=-1}
-B 2 580 -1000 1170 -540 {flags=graph
-y1=-0
-y2=500
+B 2 750 -540 1340 -80 {flags=graph
+y1=0
+y2=3.3
 ypos1=0
 ypos2=2
 divy=5
 subdivy=1
 unity=1
 x1=0
-x2=3.3
+x2=2e-07
+divx=5
+subdivx=1
+
+
+
+unitx=1
+dataset=-1
+color="4 7"
+node="in
+p"}
+B 2 750 -1000 1340 -540 {flags=graph
+y1=-2.8e-13
+y2=0
+ypos1=0
+ypos2=2
+divy=5
+subdivy=1
+unity=1
+x1=0
+x2=2e-07
 divx=5
 subdivx=1
 
@@ -55,47 +58,60 @@ subdivx=1
 unitx=1
 dataset=-1
 color=4
-node="\\"resistance; p i(vp) / -1 *\\""}
-N 130 -490 130 -440 {
+node="\\"Capac; i(v1) p deriv() /\\""}
+N 230 -470 230 -420 {
 lab=P}
-N 80 -410 110 -410 {
-lab=B}
-N 130 -380 130 -310 {
-lab=M}
-C {devices/code_shown.sym} 20 -160 0 0 {name=MODELS only_toplevel=true
+N 230 -360 230 -290 {
+lab=GND}
+N 50 -490 230 -490 {
+lab=P}
+N 230 -490 230 -470 {
+lab=P}
+N 50 -330 50 -310 {
+lab=GND}
+N 50 -310 230 -310 {
+lab=GND}
+N 50 -430 50 -390 {
+lab=IN}
+C {devices/code_shown.sym} 30 -240 0 0 {name=MODELS only_toplevel=true
 format="tcleval( @value )"
 value="
 .include $::180MCU_MODELS/design.ngspice
 .lib $::180MCU_MODELS/sm141064.ngspice typical
+.lib $::180MCU_MODELS/sm141064.ngspice cap_mim
 .lib $::180MCU_MODELS/sm141064.ngspice res_typical
+.lib $::180MCU_MODELS/sm141064.ngspice moscap_typical
+.lib $::180MCU_MODELS/sm141064.ngspice mimcap_typical
 * .lib $::180MCU_MODELS/sm141064.ngspice res_statistical
 "}
-C {devices/lab_pin.sym} 130 -490 0 0 {name=l2 sig_type=std_logic lab=P}
-C {devices/lab_pin.sym} 130 -310 0 0 {name=l3 sig_type=std_logic lab=M}
-C {devices/lab_pin.sym} 80 -410 0 0 {name=l4 sig_type=std_logic lab=B}
-C {devices/code_shown.sym} 300 -450 0 0 {name=NGSPICE only_toplevel=true
+C {devices/code_shown.sym} 430 -440 0 0 {name=NGSPICE only_toplevel=true
 value="
-vp p 0 0
-vm m 0 0
-vb b 0 3.3
-
 .control
 save all
-dc vp 0 3.3 0.01
-write test_ppolyf_u.raw
+tran 0.1n 200n
+write test_cap_mim_analog.raw
 .endc
 "}
 C {devices/title.sym} 160 -30 0 0 {name=l5 author="GlobalFoundries PDK Authors"}
-C {devices/launcher.sym} 65 -645 0 0 {name=h1
+C {devices/launcher.sym} 185 -635 0 0 {name=h1
 descr="Click left mouse button here with control key
 pressed to load/unload waveforms in graph."
 tclcommand="
 xschem raw_read $netlist_dir/[file tail [file rootname [xschem get current_name]]].raw
 "
 }
-C {symbols/ppolyf_u.sym} 130 -410 0 0 {name=R1
-W=1e-6
-L=1e-6
-model=ppolyf_u
+C {symbols/cap_mim_analog.sym} 230 -390 0 0 {name=C1
+W=10e-6
+L=10e-6
+model=cap_mim_2f0_m2m3_noshield
 spiceprefix=X
 m=1}
+C {devices/vsource.sym} 50 -360 0 0 {name=V1 value="pwl 0 0 200n 3.3"}
+C {devices/res.sym} 50 -460 0 0 {name=R2
+value=100k
+footprint=1206
+device=resistor
+m=1}
+C {devices/lab_pin.sym} 50 -410 0 0 {name=l1 sig_type=std_logic lab=IN}
+C {devices/gnd.sym} 230 -290 0 0 {name=l2 lab=GND}
+C {devices/lab_pin.sym} 230 -490 0 1 {name=l3 sig_type=std_logic lab=P}

--- a/cells/xschem/tests/test_cap_mim_analog.sym
+++ b/cells/xschem/tests/test_cap_mim_analog.sym
@@ -1,4 +1,4 @@
-v {xschem version=3.4.5 file_version=1.2
+v {xschem version=3.0.0 file_version=1.2
 
 * Copyright 2022 GlobalFoundries PDK Authors
 *
@@ -15,26 +15,13 @@ v {xschem version=3.4.5 file_version=1.2
 * limitations under the License.
 
 }
-G {}
-K {type=moscap
-format="@spiceprefix@name @pinlist @model c_width=@W c_length=@L m=@m"
-template="name=C1
-W=1e-6
-L=1e-6
-model=cap_nmos_03v3
-spiceprefix=X
-m=1"
+K {type=subcircuit
+format="@name @pinlist @symname"
+template="name=x1"
 }
-V {}
-S {}
-E {}
-L 4 0 10 0 30 {}
-L 4 0 -30 0 -5 {}
-L 4 -15 -5 15 -5 {}
-B 4 -15 5 15 10 {}
-B 5 -2.5 -32.5 2.5 -27.5 {name=G dir=inout propag=1 pinnumber=2}
-B 5 -2.5 27.5 2.5 32.5 {name=B dir=inout propag=0 pinnumber=1}
-T {@m * @W / @L} 20 6.25 0 0 0.2 0.2 {layer=13}
-T {@model} 20 -11.25 0 0 0.2 0.2 {}
-T {@spiceprefix@name} 20 -28.75 0 0 0.2 0.2 {}
-T {PW} -25 12.5 0 0 0.2 0.2 { layer=4}
+T {@symname} -76.5 -6 0 0 0.3 0.3 {}
+T {@name} 135 -22 0 0 0.2 0.2 {}
+L 4 -130 -10 130 -10 {}
+L 4 -130 10 130 10 {}
+L 4 -130 -10 -130 10 {}
+L 4 130 -10 130 10 {}

--- a/cells/xschem/tests/test_cap_nmos_03v3_b.sch
+++ b/cells/xschem/tests/test_cap_nmos_03v3_b.sch
@@ -20,33 +20,36 @@ K {}
 V {}
 S {}
 E {}
-B 2 580 -540 1170 -80 {flags=graph
-y1=-0.0067
-y2=0
-ypos1=0
-ypos2=2
-divy=5
-subdivy=1
-unity=m
-x1=0
-x2=3.3
-divx=5
-subdivx=1
-node=i(vp)
-color=4
-
-unitx=1
-dataset=-1}
-B 2 580 -1000 1170 -540 {flags=graph
-y1=-0
-y2=500
+B 2 750 -540 1340 -80 {flags=graph
+y1=0.00043
+y2=3.3
 ypos1=0
 ypos2=2
 divy=5
 subdivy=1
 unity=1
 x1=0
-x2=3.3
+x2=2e-07
+divx=5
+subdivx=1
+
+
+
+unitx=1
+dataset=-1
+color="4 7"
+node="in
+p"}
+B 2 750 -1000 1340 -540 {flags=graph
+y1=-4e-13
+y2=0
+ypos1=0
+ypos2=2
+divy=5
+subdivy=1
+unity=1
+x1=0
+x2=2e-07
 divx=5
 subdivx=1
 
@@ -55,47 +58,58 @@ subdivx=1
 unitx=1
 dataset=-1
 color=4
-node="\\"resistance; p i(vp) / -1 *\\""}
-N 130 -490 130 -440 {
+node="\\"Capac; i(v1) p deriv() /\\""}
+N 230 -470 230 -420 {
 lab=P}
-N 80 -410 110 -410 {
-lab=B}
-N 130 -380 130 -310 {
-lab=M}
-C {devices/code_shown.sym} 20 -160 0 0 {name=MODELS only_toplevel=true
+N 230 -360 230 -290 {
+lab=GND}
+N 50 -490 230 -490 {
+lab=P}
+N 230 -490 230 -470 {
+lab=P}
+N 50 -330 50 -310 {
+lab=GND}
+N 50 -310 230 -310 {
+lab=GND}
+N 50 -430 50 -390 {
+lab=IN}
+C {devices/code_shown.sym} 30 -200 0 0 {name=MODELS only_toplevel=true
 format="tcleval( @value )"
 value="
 .include $::180MCU_MODELS/design.ngspice
 .lib $::180MCU_MODELS/sm141064.ngspice typical
 .lib $::180MCU_MODELS/sm141064.ngspice res_typical
+.lib $::180MCU_MODELS/sm141064.ngspice moscap_typical
 * .lib $::180MCU_MODELS/sm141064.ngspice res_statistical
 "}
-C {devices/lab_pin.sym} 130 -490 0 0 {name=l2 sig_type=std_logic lab=P}
-C {devices/lab_pin.sym} 130 -310 0 0 {name=l3 sig_type=std_logic lab=M}
-C {devices/lab_pin.sym} 80 -410 0 0 {name=l4 sig_type=std_logic lab=B}
-C {devices/code_shown.sym} 300 -450 0 0 {name=NGSPICE only_toplevel=true
+C {devices/code_shown.sym} 390 -450 0 0 {name=NGSPICE only_toplevel=true
 value="
-vp p 0 0
-vm m 0 0
-vb b 0 3.3
-
 .control
 save all
-dc vp 0 3.3 0.01
-write test_ppolyf_u.raw
+tran 0.1n 200n
+write test_cap_nmos_03v3_b.raw
 .endc
 "}
 C {devices/title.sym} 160 -30 0 0 {name=l5 author="GlobalFoundries PDK Authors"}
-C {devices/launcher.sym} 65 -645 0 0 {name=h1
+C {devices/launcher.sym} 185 -635 0 0 {name=h1
 descr="Click left mouse button here with control key
 pressed to load/unload waveforms in graph."
 tclcommand="
 xschem raw_read $netlist_dir/[file tail [file rootname [xschem get current_name]]].raw
 "
 }
-C {symbols/ppolyf_u.sym} 130 -410 0 0 {name=R1
-W=1e-6
-L=1e-6
-model=ppolyf_u
+C {symbols/cap_nmos_03v3_b.sym} 230 -390 0 0 {name=C1
+W=10e-6
+L=10e-6
+model=cap_nmos_03v3_b
 spiceprefix=X
 m=1}
+C {devices/vsource.sym} 50 -360 0 0 {name=V1 value="pwl 0 0 200n 3.3"}
+C {devices/res.sym} 50 -460 0 0 {name=R2
+value=100k
+footprint=1206
+device=resistor
+m=1}
+C {devices/lab_pin.sym} 50 -410 0 0 {name=l1 sig_type=std_logic lab=IN}
+C {devices/gnd.sym} 230 -290 0 0 {name=l2 lab=GND}
+C {devices/lab_pin.sym} 230 -490 0 1 {name=l3 sig_type=std_logic lab=P}

--- a/cells/xschem/tests/test_cap_nmos_03v3_b.sym
+++ b/cells/xschem/tests/test_cap_nmos_03v3_b.sym
@@ -1,4 +1,4 @@
-v {xschem version=3.4.5 file_version=1.2
+v {xschem version=3.0.0 file_version=1.2
 
 * Copyright 2022 GlobalFoundries PDK Authors
 *
@@ -15,26 +15,13 @@ v {xschem version=3.4.5 file_version=1.2
 * limitations under the License.
 
 }
-G {}
-K {type=moscap
-format="@spiceprefix@name @pinlist @model c_width=@W c_length=@L m=@m"
-template="name=C1
-W=1e-6
-L=1e-6
-model=cap_nmos_03v3
-spiceprefix=X
-m=1"
+K {type=subcircuit
+format="@name @pinlist @symname"
+template="name=x1"
 }
-V {}
-S {}
-E {}
-L 4 0 10 0 30 {}
-L 4 0 -30 0 -5 {}
-L 4 -15 -5 15 -5 {}
-B 4 -15 5 15 10 {}
-B 5 -2.5 -32.5 2.5 -27.5 {name=G dir=inout propag=1 pinnumber=2}
-B 5 -2.5 27.5 2.5 32.5 {name=B dir=inout propag=0 pinnumber=1}
-T {@m * @W / @L} 20 6.25 0 0 0.2 0.2 {layer=13}
-T {@model} 20 -11.25 0 0 0.2 0.2 {}
-T {@spiceprefix@name} 20 -28.75 0 0 0.2 0.2 {}
-T {PW} -25 12.5 0 0 0.2 0.2 { layer=4}
+T {@symname} -76.5 -6 0 0 0.3 0.3 {}
+T {@name} 135 -22 0 0 0.2 0.2 {}
+L 4 -130 -10 130 -10 {}
+L 4 -130 10 130 10 {}
+L 4 -130 -10 -130 10 {}
+L 4 130 -10 130 10 {}

--- a/cells/xschem/tests/test_cap_nmos_06v0_b.sch
+++ b/cells/xschem/tests/test_cap_nmos_06v0_b.sch
@@ -20,33 +20,36 @@ K {}
 V {}
 S {}
 E {}
-B 2 580 -540 1170 -80 {flags=graph
-y1=-0.0067
-y2=0
-ypos1=0
-ypos2=2
-divy=5
-subdivy=1
-unity=m
-x1=0
-x2=3.3
-divx=5
-subdivx=1
-node=i(vp)
-color=4
-
-unitx=1
-dataset=-1}
-B 2 580 -1000 1170 -540 {flags=graph
-y1=-0
-y2=500
+B 2 750 -540 1340 -80 {flags=graph
+y1=0
+y2=6
 ypos1=0
 ypos2=2
 divy=5
 subdivy=1
 unity=1
 x1=0
-x2=3.3
+x2=2e-07
+divx=5
+subdivx=1
+
+
+
+unitx=1
+dataset=-1
+color="4 7"
+node="in
+p"}
+B 2 750 -1000 1340 -540 {flags=graph
+y1=-2.2e-13
+y2=0
+ypos1=0
+ypos2=2
+divy=5
+subdivy=1
+unity=1
+x1=0
+x2=2e-07
 divx=5
 subdivx=1
 
@@ -55,47 +58,58 @@ subdivx=1
 unitx=1
 dataset=-1
 color=4
-node="\\"resistance; p i(vp) / -1 *\\""}
-N 130 -490 130 -440 {
+node="\\"Capac; i(v1) p deriv() /\\""}
+N 230 -470 230 -420 {
 lab=P}
-N 80 -410 110 -410 {
-lab=B}
-N 130 -380 130 -310 {
-lab=M}
-C {devices/code_shown.sym} 20 -160 0 0 {name=MODELS only_toplevel=true
+N 230 -360 230 -290 {
+lab=GND}
+N 50 -490 230 -490 {
+lab=P}
+N 230 -490 230 -470 {
+lab=P}
+N 50 -330 50 -310 {
+lab=GND}
+N 50 -310 230 -310 {
+lab=GND}
+N 50 -430 50 -390 {
+lab=IN}
+C {devices/code_shown.sym} 30 -200 0 0 {name=MODELS only_toplevel=true
 format="tcleval( @value )"
 value="
 .include $::180MCU_MODELS/design.ngspice
 .lib $::180MCU_MODELS/sm141064.ngspice typical
 .lib $::180MCU_MODELS/sm141064.ngspice res_typical
+.lib $::180MCU_MODELS/sm141064.ngspice moscap_typical
 * .lib $::180MCU_MODELS/sm141064.ngspice res_statistical
 "}
-C {devices/lab_pin.sym} 130 -490 0 0 {name=l2 sig_type=std_logic lab=P}
-C {devices/lab_pin.sym} 130 -310 0 0 {name=l3 sig_type=std_logic lab=M}
-C {devices/lab_pin.sym} 80 -410 0 0 {name=l4 sig_type=std_logic lab=B}
-C {devices/code_shown.sym} 300 -450 0 0 {name=NGSPICE only_toplevel=true
+C {devices/code_shown.sym} 390 -450 0 0 {name=NGSPICE only_toplevel=true
 value="
-vp p 0 0
-vm m 0 0
-vb b 0 3.3
-
 .control
 save all
-dc vp 0 3.3 0.01
-write test_ppolyf_u.raw
+tran 0.1n 200n
+write test_cap_nmos_06v0_b.raw
 .endc
 "}
 C {devices/title.sym} 160 -30 0 0 {name=l5 author="GlobalFoundries PDK Authors"}
-C {devices/launcher.sym} 65 -645 0 0 {name=h1
+C {devices/launcher.sym} 185 -635 0 0 {name=h1
 descr="Click left mouse button here with control key
 pressed to load/unload waveforms in graph."
 tclcommand="
 xschem raw_read $netlist_dir/[file tail [file rootname [xschem get current_name]]].raw
 "
 }
-C {symbols/ppolyf_u.sym} 130 -410 0 0 {name=R1
-W=1e-6
-L=1e-6
-model=ppolyf_u
+C {symbols/cap_nmos_06v0_b.sym} 230 -390 0 0 {name=C1
+W=10e-6
+L=10e-6
+model=cap_nmos_06v0_b
 spiceprefix=X
 m=1}
+C {devices/vsource.sym} 50 -360 0 0 {name=V1 value="pwl 0 0 200n 6.0"}
+C {devices/res.sym} 50 -460 0 0 {name=R2
+value=100k
+footprint=1206
+device=resistor
+m=1}
+C {devices/lab_pin.sym} 50 -410 0 0 {name=l1 sig_type=std_logic lab=IN}
+C {devices/gnd.sym} 230 -290 0 0 {name=l2 lab=GND}
+C {devices/lab_pin.sym} 230 -490 0 1 {name=l3 sig_type=std_logic lab=P}

--- a/cells/xschem/tests/test_cap_nmos_06v0_b.sym
+++ b/cells/xschem/tests/test_cap_nmos_06v0_b.sym
@@ -1,4 +1,4 @@
-v {xschem version=3.4.5 file_version=1.2
+v {xschem version=3.0.0 file_version=1.2
 
 * Copyright 2022 GlobalFoundries PDK Authors
 *
@@ -15,26 +15,13 @@ v {xschem version=3.4.5 file_version=1.2
 * limitations under the License.
 
 }
-G {}
-K {type=moscap
-format="@spiceprefix@name @pinlist @model c_width=@W c_length=@L m=@m"
-template="name=C1
-W=1e-6
-L=1e-6
-model=cap_nmos_03v3
-spiceprefix=X
-m=1"
+K {type=subcircuit
+format="@name @pinlist @symname"
+template="name=x1"
 }
-V {}
-S {}
-E {}
-L 4 0 10 0 30 {}
-L 4 0 -30 0 -5 {}
-L 4 -15 -5 15 -5 {}
-B 4 -15 5 15 10 {}
-B 5 -2.5 -32.5 2.5 -27.5 {name=G dir=inout propag=1 pinnumber=2}
-B 5 -2.5 27.5 2.5 32.5 {name=B dir=inout propag=0 pinnumber=1}
-T {@m * @W / @L} 20 6.25 0 0 0.2 0.2 {layer=13}
-T {@model} 20 -11.25 0 0 0.2 0.2 {}
-T {@spiceprefix@name} 20 -28.75 0 0 0.2 0.2 {}
-T {PW} -25 12.5 0 0 0.2 0.2 { layer=4}
+T {@symname} -76.5 -6 0 0 0.3 0.3 {}
+T {@name} 135 -22 0 0 0.2 0.2 {}
+L 4 -130 -10 130 -10 {}
+L 4 -130 10 130 10 {}
+L 4 -130 -10 -130 10 {}
+L 4 130 -10 130 10 {}

--- a/cells/xschem/tests/test_cap_pmos_03v3_b.sch
+++ b/cells/xschem/tests/test_cap_pmos_03v3_b.sch
@@ -20,33 +20,36 @@ K {}
 V {}
 S {}
 E {}
-B 2 580 -540 1170 -80 {flags=graph
-y1=-0.0067
-y2=0
-ypos1=0
-ypos2=2
-divy=5
-subdivy=1
-unity=m
-x1=0
-x2=3.3
-divx=5
-subdivx=1
-node=i(vp)
-color=4
-
-unitx=1
-dataset=-1}
-B 2 580 -1000 1170 -540 {flags=graph
-y1=-0
-y2=500
+B 2 750 -540 1340 -80 {flags=graph
+y1=0
+y2=3.3
 ypos1=0
 ypos2=2
 divy=5
 subdivy=1
 unity=1
 x1=0
-x2=3.3
+x2=2e-07
+divx=5
+subdivx=1
+
+
+
+unitx=1
+dataset=-1
+color="4 7"
+node="in
+m"}
+B 2 750 -1000 1340 -540 {flags=graph
+y1=0
+y2=4e-13
+ypos1=0
+ypos2=2
+divy=5
+subdivy=1
+unity=1
+x1=0
+x2=2e-07
 divx=5
 subdivx=1
 
@@ -55,47 +58,59 @@ subdivx=1
 unitx=1
 dataset=-1
 color=4
-node="\\"resistance; p i(vp) / -1 *\\""}
-N 130 -490 130 -440 {
-lab=P}
-N 80 -410 110 -410 {
-lab=B}
-N 130 -380 130 -310 {
+node="\\"Capac; i(v1) m deriv() /\\""}
+N 230 -470 230 -420 {
+lab=VDD}
+N 230 -490 230 -470 {
+lab=VDD}
+N 50 -330 50 -310 {
 lab=M}
-C {devices/code_shown.sym} 20 -160 0 0 {name=MODELS only_toplevel=true
+N 50 -310 230 -310 {
+lab=M}
+N 50 -430 50 -390 {
+lab=IN}
+N 50 -490 230 -490 {
+lab=VDD}
+N 230 -360 230 -310 {
+lab=M}
+C {devices/code_shown.sym} 30 -200 0 0 {name=MODELS only_toplevel=true
 format="tcleval( @value )"
 value="
 .include $::180MCU_MODELS/design.ngspice
 .lib $::180MCU_MODELS/sm141064.ngspice typical
 .lib $::180MCU_MODELS/sm141064.ngspice res_typical
+.lib $::180MCU_MODELS/sm141064.ngspice moscap_typical
 * .lib $::180MCU_MODELS/sm141064.ngspice res_statistical
 "}
-C {devices/lab_pin.sym} 130 -490 0 0 {name=l2 sig_type=std_logic lab=P}
-C {devices/lab_pin.sym} 130 -310 0 0 {name=l3 sig_type=std_logic lab=M}
-C {devices/lab_pin.sym} 80 -410 0 0 {name=l4 sig_type=std_logic lab=B}
-C {devices/code_shown.sym} 300 -450 0 0 {name=NGSPICE only_toplevel=true
+C {devices/code_shown.sym} 390 -450 0 0 {name=NGSPICE only_toplevel=true
 value="
-vp p 0 0
-vm m 0 0
-vb b 0 3.3
-
+vvdd vdd 0 3.3
 .control
 save all
-dc vp 0 3.3 0.01
-write test_ppolyf_u.raw
+tran 0.1n 200n
+write test_cap_pmos_03v3_b.raw
 .endc
 "}
 C {devices/title.sym} 160 -30 0 0 {name=l5 author="GlobalFoundries PDK Authors"}
-C {devices/launcher.sym} 65 -645 0 0 {name=h1
+C {devices/launcher.sym} 185 -635 0 0 {name=h1
 descr="Click left mouse button here with control key
 pressed to load/unload waveforms in graph."
 tclcommand="
 xschem raw_read $netlist_dir/[file tail [file rootname [xschem get current_name]]].raw
 "
 }
-C {symbols/ppolyf_u.sym} 130 -410 0 0 {name=R1
-W=1e-6
-L=1e-6
-model=ppolyf_u
+C {symbols/cap_pmos_03v3_b.sym} 230 -390 0 0 {name=C1
+W=10e-6
+L=10e-6
+model=cap_pmos_03v3_b
 spiceprefix=X
 m=1}
+C {devices/vsource.sym} 50 -460 0 0 {name=V1 value="pwl 0 0 200n 3.3"}
+C {devices/res.sym} 50 -360 0 0 {name=R2
+value=100k
+footprint=1206
+device=resistor
+m=1}
+C {devices/lab_pin.sym} 50 -410 0 0 {name=l1 sig_type=std_logic lab=IN}
+C {devices/vdd.sym} 230 -490 0 0 {name=l3 lab=VDD}
+C {devices/lab_pin.sym} 230 -310 0 1 {name=l2 sig_type=std_logic lab=M}

--- a/cells/xschem/tests/test_cap_pmos_03v3_b.sym
+++ b/cells/xschem/tests/test_cap_pmos_03v3_b.sym
@@ -1,4 +1,4 @@
-v {xschem version=3.4.5 file_version=1.2
+v {xschem version=3.0.0 file_version=1.2
 
 * Copyright 2022 GlobalFoundries PDK Authors
 *
@@ -15,26 +15,13 @@ v {xschem version=3.4.5 file_version=1.2
 * limitations under the License.
 
 }
-G {}
-K {type=moscap
-format="@spiceprefix@name @pinlist @model c_width=@W c_length=@L m=@m"
-template="name=C1
-W=1e-6
-L=1e-6
-model=cap_nmos_03v3
-spiceprefix=X
-m=1"
+K {type=subcircuit
+format="@name @pinlist @symname"
+template="name=x1"
 }
-V {}
-S {}
-E {}
-L 4 0 10 0 30 {}
-L 4 0 -30 0 -5 {}
-L 4 -15 -5 15 -5 {}
-B 4 -15 5 15 10 {}
-B 5 -2.5 -32.5 2.5 -27.5 {name=G dir=inout propag=1 pinnumber=2}
-B 5 -2.5 27.5 2.5 32.5 {name=B dir=inout propag=0 pinnumber=1}
-T {@m * @W / @L} 20 6.25 0 0 0.2 0.2 {layer=13}
-T {@model} 20 -11.25 0 0 0.2 0.2 {}
-T {@spiceprefix@name} 20 -28.75 0 0 0.2 0.2 {}
-T {PW} -25 12.5 0 0 0.2 0.2 { layer=4}
+T {@symname} -76.5 -6 0 0 0.3 0.3 {}
+T {@name} 135 -22 0 0 0.2 0.2 {}
+L 4 -130 -10 130 -10 {}
+L 4 -130 10 130 10 {}
+L 4 -130 -10 -130 10 {}
+L 4 130 -10 130 10 {}

--- a/cells/xschem/tests/test_cap_pmos_06v0_b.sch
+++ b/cells/xschem/tests/test_cap_pmos_06v0_b.sch
@@ -20,33 +20,36 @@ K {}
 V {}
 S {}
 E {}
-B 2 580 -540 1170 -80 {flags=graph
-y1=-0.0067
-y2=0
-ypos1=0
-ypos2=2
-divy=5
-subdivy=1
-unity=m
-x1=0
-x2=3.3
-divx=5
-subdivx=1
-node=i(vp)
-color=4
-
-unitx=1
-dataset=-1}
-B 2 580 -1000 1170 -540 {flags=graph
-y1=-0
-y2=500
+B 2 750 -540 1340 -80 {flags=graph
+y1=0.00081
+y2=6
 ypos1=0
 ypos2=2
 divy=5
 subdivy=1
 unity=1
 x1=0
-x2=3.3
+x2=2e-07
+divx=5
+subdivx=1
+
+
+
+unitx=1
+dataset=-1
+color="4 7"
+node="in
+m"}
+B 2 750 -1000 1340 -540 {flags=graph
+y1=0
+y2=3e-13
+ypos1=0
+ypos2=2
+divy=5
+subdivy=1
+unity=1
+x1=0
+x2=2e-07
 divx=5
 subdivx=1
 
@@ -55,47 +58,59 @@ subdivx=1
 unitx=1
 dataset=-1
 color=4
-node="\\"resistance; p i(vp) / -1 *\\""}
-N 130 -490 130 -440 {
-lab=P}
-N 80 -410 110 -410 {
-lab=B}
-N 130 -380 130 -310 {
+node="\\"Capac; i(v1) m deriv() /\\""}
+N 230 -470 230 -420 {
+lab=VDD}
+N 230 -490 230 -470 {
+lab=VDD}
+N 50 -330 50 -310 {
 lab=M}
-C {devices/code_shown.sym} 20 -160 0 0 {name=MODELS only_toplevel=true
+N 50 -310 230 -310 {
+lab=M}
+N 50 -430 50 -390 {
+lab=IN}
+N 50 -490 230 -490 {
+lab=VDD}
+N 230 -360 230 -310 {
+lab=M}
+C {devices/code_shown.sym} 30 -200 0 0 {name=MODELS only_toplevel=true
 format="tcleval( @value )"
 value="
 .include $::180MCU_MODELS/design.ngspice
 .lib $::180MCU_MODELS/sm141064.ngspice typical
 .lib $::180MCU_MODELS/sm141064.ngspice res_typical
+.lib $::180MCU_MODELS/sm141064.ngspice moscap_typical
 * .lib $::180MCU_MODELS/sm141064.ngspice res_statistical
 "}
-C {devices/lab_pin.sym} 130 -490 0 0 {name=l2 sig_type=std_logic lab=P}
-C {devices/lab_pin.sym} 130 -310 0 0 {name=l3 sig_type=std_logic lab=M}
-C {devices/lab_pin.sym} 80 -410 0 0 {name=l4 sig_type=std_logic lab=B}
-C {devices/code_shown.sym} 300 -450 0 0 {name=NGSPICE only_toplevel=true
+C {devices/code_shown.sym} 390 -450 0 0 {name=NGSPICE only_toplevel=true
 value="
-vp p 0 0
-vm m 0 0
-vb b 0 3.3
-
+vvdd vdd 0 6.0
 .control
 save all
-dc vp 0 3.3 0.01
-write test_ppolyf_u.raw
+tran 0.1n 200n
+write test_cap_pmos_06v0_b.raw
 .endc
 "}
 C {devices/title.sym} 160 -30 0 0 {name=l5 author="GlobalFoundries PDK Authors"}
-C {devices/launcher.sym} 65 -645 0 0 {name=h1
+C {devices/launcher.sym} 185 -635 0 0 {name=h1
 descr="Click left mouse button here with control key
 pressed to load/unload waveforms in graph."
 tclcommand="
 xschem raw_read $netlist_dir/[file tail [file rootname [xschem get current_name]]].raw
 "
 }
-C {symbols/ppolyf_u.sym} 130 -410 0 0 {name=R1
-W=1e-6
-L=1e-6
-model=ppolyf_u
+C {symbols/cap_pmos_06v0_b.sym} 230 -390 0 0 {name=C1
+W=10e-6
+L=10e-6
+model=cap_pmos_06v0_b
 spiceprefix=X
 m=1}
+C {devices/vsource.sym} 50 -460 0 0 {name=V1 value="pwl 0 0 200n 6.0"}
+C {devices/res.sym} 50 -360 0 0 {name=R2
+value=100k
+footprint=1206
+device=resistor
+m=1}
+C {devices/lab_pin.sym} 50 -410 0 0 {name=l1 sig_type=std_logic lab=IN}
+C {devices/vdd.sym} 230 -490 0 0 {name=l3 lab=VDD}
+C {devices/lab_pin.sym} 230 -310 0 1 {name=l2 sig_type=std_logic lab=M}

--- a/cells/xschem/tests/test_cap_pmos_06v0_b.sym
+++ b/cells/xschem/tests/test_cap_pmos_06v0_b.sym
@@ -1,4 +1,4 @@
-v {xschem version=3.4.5 file_version=1.2
+v {xschem version=3.0.0 file_version=1.2
 
 * Copyright 2022 GlobalFoundries PDK Authors
 *
@@ -15,26 +15,13 @@ v {xschem version=3.4.5 file_version=1.2
 * limitations under the License.
 
 }
-G {}
-K {type=moscap
-format="@spiceprefix@name @pinlist @model c_width=@W c_length=@L m=@m"
-template="name=C1
-W=1e-6
-L=1e-6
-model=cap_nmos_03v3
-spiceprefix=X
-m=1"
+K {type=subcircuit
+format="@name @pinlist @symname"
+template="name=x1"
 }
-V {}
-S {}
-E {}
-L 4 0 10 0 30 {}
-L 4 0 -30 0 -5 {}
-L 4 -15 -5 15 -5 {}
-B 4 -15 5 15 10 {}
-B 5 -2.5 -32.5 2.5 -27.5 {name=G dir=inout propag=1 pinnumber=2}
-B 5 -2.5 27.5 2.5 32.5 {name=B dir=inout propag=0 pinnumber=1}
-T {@m * @W / @L} 20 6.25 0 0 0.2 0.2 {layer=13}
-T {@model} 20 -11.25 0 0 0.2 0.2 {}
-T {@spiceprefix@name} 20 -28.75 0 0 0.2 0.2 {}
-T {PW} -25 12.5 0 0 0.2 0.2 { layer=4}
+T {@symname} -76.5 -6 0 0 0.3 0.3 {}
+T {@name} 135 -22 0 0 0.2 0.2 {}
+L 4 -130 -10 130 -10 {}
+L 4 -130 10 130 10 {}
+L 4 -130 -10 -130 10 {}
+L 4 130 -10 130 10 {}

--- a/cells/xschem/tests/test_diode_dw2ps.sch
+++ b/cells/xschem/tests/test_diode_dw2ps.sch
@@ -20,33 +20,16 @@ K {}
 V {}
 S {}
 E {}
-B 2 580 -540 1170 -80 {flags=graph
-y1=-0.0067
-y2=0
+B 2 750 -540 1340 -80 {flags=graph
+y1=-2e-06
+y2=2.6e-14
 ypos1=0
 ypos2=2
 divy=5
 subdivy=1
-unity=m
-x1=0
-x2=3.3
-divx=5
-subdivx=1
-node=i(vp)
-color=4
-
-unitx=1
-dataset=-1}
-B 2 580 -1000 1170 -540 {flags=graph
-y1=-0
-y2=500
-ypos1=0
-ypos2=2
-divy=5
-subdivy=1
-unity=1
-x1=0
-x2=3.3
+unity=u
+x1=-0.4
+x2=0.8
 divx=5
 subdivx=1
 
@@ -54,48 +37,46 @@ subdivx=1
 
 unitx=1
 dataset=-1
+
 color=4
-node="\\"resistance; p i(vp) / -1 *\\""}
-N 130 -490 130 -440 {
+node=i(vp)}
+N 230 -470 230 -420 {
 lab=P}
-N 80 -410 110 -410 {
-lab=B}
-N 130 -380 130 -310 {
-lab=M}
-C {devices/code_shown.sym} 20 -160 0 0 {name=MODELS only_toplevel=true
+N 230 -360 230 -290 {
+lab=GND}
+N 230 -490 230 -470 {
+lab=P}
+C {devices/code_shown.sym} 30 -200 0 0 {name=MODELS only_toplevel=true
 format="tcleval( @value )"
 value="
 .include $::180MCU_MODELS/design.ngspice
 .lib $::180MCU_MODELS/sm141064.ngspice typical
 .lib $::180MCU_MODELS/sm141064.ngspice res_typical
+.lib $::180MCU_MODELS/sm141064.ngspice moscap_typical
+.lib $::180MCU_MODELS/sm141064.ngspice diode_typical
 * .lib $::180MCU_MODELS/sm141064.ngspice res_statistical
 "}
-C {devices/lab_pin.sym} 130 -490 0 0 {name=l2 sig_type=std_logic lab=P}
-C {devices/lab_pin.sym} 130 -310 0 0 {name=l3 sig_type=std_logic lab=M}
-C {devices/lab_pin.sym} 80 -410 0 0 {name=l4 sig_type=std_logic lab=B}
-C {devices/code_shown.sym} 300 -450 0 0 {name=NGSPICE only_toplevel=true
+C {devices/code_shown.sym} 390 -450 0 0 {name=NGSPICE only_toplevel=true
 value="
 vp p 0 0
-vm m 0 0
-vb b 0 3.3
-
 .control
 save all
-dc vp 0 3.3 0.01
-write test_ppolyf_u.raw
+dc vp -0.4 0.8 0.001
+write test_diode_dw2ps.raw
 .endc
 "}
 C {devices/title.sym} 160 -30 0 0 {name=l5 author="GlobalFoundries PDK Authors"}
-C {devices/launcher.sym} 65 -645 0 0 {name=h1
+C {devices/launcher.sym} 185 -635 0 0 {name=h1
 descr="Click left mouse button here with control key
 pressed to load/unload waveforms in graph."
 tclcommand="
 xschem raw_read $netlist_dir/[file tail [file rootname [xschem get current_name]]].raw
 "
 }
-C {symbols/ppolyf_u.sym} 130 -410 0 0 {name=R1
-W=1e-6
-L=1e-6
-model=ppolyf_u
-spiceprefix=X
+C {devices/gnd.sym} 230 -290 0 0 {name=l2 lab=GND}
+C {devices/lab_pin.sym} 230 -490 0 1 {name=l3 sig_type=std_logic lab=P}
+C {symbols/diode_dw2ps.sym} 230 -390 0 0 {name=D1
+model=diode_dw2ps
+r_w=1u
+r_l=1u
 m=1}

--- a/cells/xschem/tests/test_diode_dw2ps.sym
+++ b/cells/xschem/tests/test_diode_dw2ps.sym
@@ -1,4 +1,4 @@
-v {xschem version=3.4.5 file_version=1.2
+v {xschem version=3.0.0 file_version=1.2
 
 * Copyright 2022 GlobalFoundries PDK Authors
 *
@@ -15,26 +15,13 @@ v {xschem version=3.4.5 file_version=1.2
 * limitations under the License.
 
 }
-G {}
-K {type=moscap
-format="@spiceprefix@name @pinlist @model c_width=@W c_length=@L m=@m"
-template="name=C1
-W=1e-6
-L=1e-6
-model=cap_nmos_03v3
-spiceprefix=X
-m=1"
+K {type=subcircuit
+format="@name @pinlist @symname"
+template="name=x1"
 }
-V {}
-S {}
-E {}
-L 4 0 10 0 30 {}
-L 4 0 -30 0 -5 {}
-L 4 -15 -5 15 -5 {}
-B 4 -15 5 15 10 {}
-B 5 -2.5 -32.5 2.5 -27.5 {name=G dir=inout propag=1 pinnumber=2}
-B 5 -2.5 27.5 2.5 32.5 {name=B dir=inout propag=0 pinnumber=1}
-T {@m * @W / @L} 20 6.25 0 0 0.2 0.2 {layer=13}
-T {@model} 20 -11.25 0 0 0.2 0.2 {}
-T {@spiceprefix@name} 20 -28.75 0 0 0.2 0.2 {}
-T {PW} -25 12.5 0 0 0.2 0.2 { layer=4}
+T {@symname} -76.5 -6 0 0 0.3 0.3 {}
+T {@name} 135 -22 0 0 0.2 0.2 {}
+L 4 -130 -10 130 -10 {}
+L 4 -130 10 130 10 {}
+L 4 -130 -10 -130 10 {}
+L 4 130 -10 130 10 {}

--- a/cells/xschem/tests/test_diode_nd2ps_06v0.sch
+++ b/cells/xschem/tests/test_diode_nd2ps_06v0.sch
@@ -20,33 +20,16 @@ K {}
 V {}
 S {}
 E {}
-B 2 580 -540 1170 -80 {flags=graph
-y1=-0.0067
-y2=0
+B 2 750 -540 1340 -80 {flags=graph
+y1=-2e-06
+y2=2.6e-14
 ypos1=0
 ypos2=2
 divy=5
 subdivy=1
-unity=m
-x1=0
-x2=3.3
-divx=5
-subdivx=1
-node=i(vp)
-color=4
-
-unitx=1
-dataset=-1}
-B 2 580 -1000 1170 -540 {flags=graph
-y1=-0
-y2=500
-ypos1=0
-ypos2=2
-divy=5
-subdivy=1
-unity=1
-x1=0
-x2=3.3
+unity=u
+x1=-0.4
+x2=0.8
 divx=5
 subdivx=1
 
@@ -54,48 +37,46 @@ subdivx=1
 
 unitx=1
 dataset=-1
+
 color=4
-node="\\"resistance; p i(vp) / -1 *\\""}
-N 130 -490 130 -440 {
+node=i(vp)}
+N 230 -470 230 -420 {
 lab=P}
-N 80 -410 110 -410 {
-lab=B}
-N 130 -380 130 -310 {
-lab=M}
-C {devices/code_shown.sym} 20 -160 0 0 {name=MODELS only_toplevel=true
+N 230 -360 230 -290 {
+lab=GND}
+N 230 -490 230 -470 {
+lab=P}
+C {devices/code_shown.sym} 30 -200 0 0 {name=MODELS only_toplevel=true
 format="tcleval( @value )"
 value="
 .include $::180MCU_MODELS/design.ngspice
 .lib $::180MCU_MODELS/sm141064.ngspice typical
 .lib $::180MCU_MODELS/sm141064.ngspice res_typical
+.lib $::180MCU_MODELS/sm141064.ngspice moscap_typical
+.lib $::180MCU_MODELS/sm141064.ngspice diode_typical
 * .lib $::180MCU_MODELS/sm141064.ngspice res_statistical
 "}
-C {devices/lab_pin.sym} 130 -490 0 0 {name=l2 sig_type=std_logic lab=P}
-C {devices/lab_pin.sym} 130 -310 0 0 {name=l3 sig_type=std_logic lab=M}
-C {devices/lab_pin.sym} 80 -410 0 0 {name=l4 sig_type=std_logic lab=B}
-C {devices/code_shown.sym} 300 -450 0 0 {name=NGSPICE only_toplevel=true
+C {devices/code_shown.sym} 390 -450 0 0 {name=NGSPICE only_toplevel=true
 value="
 vp p 0 0
-vm m 0 0
-vb b 0 3.3
-
 .control
 save all
-dc vp 0 3.3 0.01
-write test_ppolyf_u.raw
+dc vp -0.4 0.8 0.001
+write test_diode_nd2ps_06v0.raw
 .endc
 "}
 C {devices/title.sym} 160 -30 0 0 {name=l5 author="GlobalFoundries PDK Authors"}
-C {devices/launcher.sym} 65 -645 0 0 {name=h1
+C {devices/launcher.sym} 185 -635 0 0 {name=h1
 descr="Click left mouse button here with control key
 pressed to load/unload waveforms in graph."
 tclcommand="
 xschem raw_read $netlist_dir/[file tail [file rootname [xschem get current_name]]].raw
 "
 }
-C {symbols/ppolyf_u.sym} 130 -410 0 0 {name=R1
-W=1e-6
-L=1e-6
-model=ppolyf_u
-spiceprefix=X
+C {devices/gnd.sym} 230 -290 0 0 {name=l2 lab=GND}
+C {devices/lab_pin.sym} 230 -490 0 1 {name=l3 sig_type=std_logic lab=P}
+C {symbols/diode_nd2ps_06v0.sym} 230 -390 0 0 {name=D1
+model=diode_nd2ps_06v0
+r_w=1u
+r_l=1u
 m=1}

--- a/cells/xschem/tests/test_diode_nd2ps_06v0.sym
+++ b/cells/xschem/tests/test_diode_nd2ps_06v0.sym
@@ -1,4 +1,4 @@
-v {xschem version=3.4.5 file_version=1.2
+v {xschem version=3.0.0 file_version=1.2
 
 * Copyright 2022 GlobalFoundries PDK Authors
 *
@@ -15,26 +15,13 @@ v {xschem version=3.4.5 file_version=1.2
 * limitations under the License.
 
 }
-G {}
-K {type=moscap
-format="@spiceprefix@name @pinlist @model c_width=@W c_length=@L m=@m"
-template="name=C1
-W=1e-6
-L=1e-6
-model=cap_nmos_03v3
-spiceprefix=X
-m=1"
+K {type=subcircuit
+format="@name @pinlist @symname"
+template="name=x1"
 }
-V {}
-S {}
-E {}
-L 4 0 10 0 30 {}
-L 4 0 -30 0 -5 {}
-L 4 -15 -5 15 -5 {}
-B 4 -15 5 15 10 {}
-B 5 -2.5 -32.5 2.5 -27.5 {name=G dir=inout propag=1 pinnumber=2}
-B 5 -2.5 27.5 2.5 32.5 {name=B dir=inout propag=0 pinnumber=1}
-T {@m * @W / @L} 20 6.25 0 0 0.2 0.2 {layer=13}
-T {@model} 20 -11.25 0 0 0.2 0.2 {}
-T {@spiceprefix@name} 20 -28.75 0 0 0.2 0.2 {}
-T {PW} -25 12.5 0 0 0.2 0.2 { layer=4}
+T {@symname} -76.5 -6 0 0 0.3 0.3 {}
+T {@name} 135 -22 0 0 0.2 0.2 {}
+L 4 -130 -10 130 -10 {}
+L 4 -130 10 130 10 {}
+L 4 -130 -10 -130 10 {}
+L 4 130 -10 130 10 {}

--- a/cells/xschem/tests/test_diode_nw2ps_03v3.sch
+++ b/cells/xschem/tests/test_diode_nw2ps_03v3.sch
@@ -20,33 +20,16 @@ K {}
 V {}
 S {}
 E {}
-B 2 580 -540 1170 -80 {flags=graph
-y1=-0.0067
-y2=0
+B 2 750 -540 1340 -80 {flags=graph
+y1=-2e-06
+y2=2.6e-14
 ypos1=0
 ypos2=2
 divy=5
 subdivy=1
-unity=m
-x1=0
-x2=3.3
-divx=5
-subdivx=1
-node=i(vp)
-color=4
-
-unitx=1
-dataset=-1}
-B 2 580 -1000 1170 -540 {flags=graph
-y1=-0
-y2=500
-ypos1=0
-ypos2=2
-divy=5
-subdivy=1
-unity=1
-x1=0
-x2=3.3
+unity=u
+x1=-0.4
+x2=0.8
 divx=5
 subdivx=1
 
@@ -54,48 +37,46 @@ subdivx=1
 
 unitx=1
 dataset=-1
+
 color=4
-node="\\"resistance; p i(vp) / -1 *\\""}
-N 130 -490 130 -440 {
+node=i(vp)}
+N 230 -470 230 -420 {
 lab=P}
-N 80 -410 110 -410 {
-lab=B}
-N 130 -380 130 -310 {
-lab=M}
-C {devices/code_shown.sym} 20 -160 0 0 {name=MODELS only_toplevel=true
+N 230 -360 230 -290 {
+lab=GND}
+N 230 -490 230 -470 {
+lab=P}
+C {devices/code_shown.sym} 30 -200 0 0 {name=MODELS only_toplevel=true
 format="tcleval( @value )"
 value="
 .include $::180MCU_MODELS/design.ngspice
 .lib $::180MCU_MODELS/sm141064.ngspice typical
 .lib $::180MCU_MODELS/sm141064.ngspice res_typical
+.lib $::180MCU_MODELS/sm141064.ngspice moscap_typical
+.lib $::180MCU_MODELS/sm141064.ngspice diode_typical
 * .lib $::180MCU_MODELS/sm141064.ngspice res_statistical
 "}
-C {devices/lab_pin.sym} 130 -490 0 0 {name=l2 sig_type=std_logic lab=P}
-C {devices/lab_pin.sym} 130 -310 0 0 {name=l3 sig_type=std_logic lab=M}
-C {devices/lab_pin.sym} 80 -410 0 0 {name=l4 sig_type=std_logic lab=B}
-C {devices/code_shown.sym} 300 -450 0 0 {name=NGSPICE only_toplevel=true
+C {devices/code_shown.sym} 390 -450 0 0 {name=NGSPICE only_toplevel=true
 value="
 vp p 0 0
-vm m 0 0
-vb b 0 3.3
-
 .control
 save all
-dc vp 0 3.3 0.01
-write test_ppolyf_u.raw
+dc vp -0.4 0.8 0.001
+write test_diode_nw2ps_03v3.raw
 .endc
 "}
 C {devices/title.sym} 160 -30 0 0 {name=l5 author="GlobalFoundries PDK Authors"}
-C {devices/launcher.sym} 65 -645 0 0 {name=h1
+C {devices/launcher.sym} 185 -635 0 0 {name=h1
 descr="Click left mouse button here with control key
 pressed to load/unload waveforms in graph."
 tclcommand="
 xschem raw_read $netlist_dir/[file tail [file rootname [xschem get current_name]]].raw
 "
 }
-C {symbols/ppolyf_u.sym} 130 -410 0 0 {name=R1
-W=1e-6
-L=1e-6
-model=ppolyf_u
-spiceprefix=X
+C {devices/gnd.sym} 230 -290 0 0 {name=l2 lab=GND}
+C {devices/lab_pin.sym} 230 -490 0 1 {name=l3 sig_type=std_logic lab=P}
+C {symbols/diode_nw2ps_03v3.sym} 230 -390 0 0 {name=D1
+model=diode_nw2ps_03v3
+r_w=1u
+r_l=1u
 m=1}

--- a/cells/xschem/tests/test_diode_nw2ps_03v3.sym
+++ b/cells/xschem/tests/test_diode_nw2ps_03v3.sym
@@ -1,4 +1,4 @@
-v {xschem version=3.4.5 file_version=1.2
+v {xschem version=3.0.0 file_version=1.2
 
 * Copyright 2022 GlobalFoundries PDK Authors
 *
@@ -15,26 +15,13 @@ v {xschem version=3.4.5 file_version=1.2
 * limitations under the License.
 
 }
-G {}
-K {type=moscap
-format="@spiceprefix@name @pinlist @model c_width=@W c_length=@L m=@m"
-template="name=C1
-W=1e-6
-L=1e-6
-model=cap_nmos_03v3
-spiceprefix=X
-m=1"
+K {type=subcircuit
+format="@name @pinlist @symname"
+template="name=x1"
 }
-V {}
-S {}
-E {}
-L 4 0 10 0 30 {}
-L 4 0 -30 0 -5 {}
-L 4 -15 -5 15 -5 {}
-B 4 -15 5 15 10 {}
-B 5 -2.5 -32.5 2.5 -27.5 {name=G dir=inout propag=1 pinnumber=2}
-B 5 -2.5 27.5 2.5 32.5 {name=B dir=inout propag=0 pinnumber=1}
-T {@m * @W / @L} 20 6.25 0 0 0.2 0.2 {layer=13}
-T {@model} 20 -11.25 0 0 0.2 0.2 {}
-T {@spiceprefix@name} 20 -28.75 0 0 0.2 0.2 {}
-T {PW} -25 12.5 0 0 0.2 0.2 { layer=4}
+T {@symname} -76.5 -6 0 0 0.3 0.3 {}
+T {@name} 135 -22 0 0 0.2 0.2 {}
+L 4 -130 -10 130 -10 {}
+L 4 -130 10 130 10 {}
+L 4 -130 -10 -130 10 {}
+L 4 130 -10 130 10 {}

--- a/cells/xschem/tests/test_diode_nw2ps_06v0.sch
+++ b/cells/xschem/tests/test_diode_nw2ps_06v0.sch
@@ -20,33 +20,16 @@ K {}
 V {}
 S {}
 E {}
-B 2 580 -540 1170 -80 {flags=graph
-y1=-0.0067
-y2=0
+B 2 750 -540 1340 -80 {flags=graph
+y1=-2e-06
+y2=2.6e-14
 ypos1=0
 ypos2=2
 divy=5
 subdivy=1
-unity=m
-x1=0
-x2=3.3
-divx=5
-subdivx=1
-node=i(vp)
-color=4
-
-unitx=1
-dataset=-1}
-B 2 580 -1000 1170 -540 {flags=graph
-y1=-0
-y2=500
-ypos1=0
-ypos2=2
-divy=5
-subdivy=1
-unity=1
-x1=0
-x2=3.3
+unity=u
+x1=-0.4
+x2=0.8
 divx=5
 subdivx=1
 
@@ -54,48 +37,46 @@ subdivx=1
 
 unitx=1
 dataset=-1
+
 color=4
-node="\\"resistance; p i(vp) / -1 *\\""}
-N 130 -490 130 -440 {
+node=i(vp)}
+N 230 -470 230 -420 {
 lab=P}
-N 80 -410 110 -410 {
-lab=B}
-N 130 -380 130 -310 {
-lab=M}
-C {devices/code_shown.sym} 20 -160 0 0 {name=MODELS only_toplevel=true
+N 230 -360 230 -290 {
+lab=GND}
+N 230 -490 230 -470 {
+lab=P}
+C {devices/code_shown.sym} 30 -200 0 0 {name=MODELS only_toplevel=true
 format="tcleval( @value )"
 value="
 .include $::180MCU_MODELS/design.ngspice
 .lib $::180MCU_MODELS/sm141064.ngspice typical
 .lib $::180MCU_MODELS/sm141064.ngspice res_typical
+.lib $::180MCU_MODELS/sm141064.ngspice moscap_typical
+.lib $::180MCU_MODELS/sm141064.ngspice diode_typical
 * .lib $::180MCU_MODELS/sm141064.ngspice res_statistical
 "}
-C {devices/lab_pin.sym} 130 -490 0 0 {name=l2 sig_type=std_logic lab=P}
-C {devices/lab_pin.sym} 130 -310 0 0 {name=l3 sig_type=std_logic lab=M}
-C {devices/lab_pin.sym} 80 -410 0 0 {name=l4 sig_type=std_logic lab=B}
-C {devices/code_shown.sym} 300 -450 0 0 {name=NGSPICE only_toplevel=true
+C {devices/code_shown.sym} 390 -450 0 0 {name=NGSPICE only_toplevel=true
 value="
 vp p 0 0
-vm m 0 0
-vb b 0 3.3
-
 .control
 save all
-dc vp 0 3.3 0.01
-write test_ppolyf_u.raw
+dc vp -0.4 0.8 0.001
+write test_diode_nw2ps_06v0.raw
 .endc
 "}
 C {devices/title.sym} 160 -30 0 0 {name=l5 author="GlobalFoundries PDK Authors"}
-C {devices/launcher.sym} 65 -645 0 0 {name=h1
+C {devices/launcher.sym} 185 -635 0 0 {name=h1
 descr="Click left mouse button here with control key
 pressed to load/unload waveforms in graph."
 tclcommand="
 xschem raw_read $netlist_dir/[file tail [file rootname [xschem get current_name]]].raw
 "
 }
-C {symbols/ppolyf_u.sym} 130 -410 0 0 {name=R1
-W=1e-6
-L=1e-6
-model=ppolyf_u
-spiceprefix=X
+C {devices/gnd.sym} 230 -290 0 0 {name=l2 lab=GND}
+C {devices/lab_pin.sym} 230 -490 0 1 {name=l3 sig_type=std_logic lab=P}
+C {symbols/diode_nw2ps_06v0.sym} 230 -390 0 0 {name=D1
+model=diode_nw2ps_06v0
+r_w=1u
+r_l=1u
 m=1}

--- a/cells/xschem/tests/test_diode_nw2ps_06v0.sym
+++ b/cells/xschem/tests/test_diode_nw2ps_06v0.sym
@@ -1,4 +1,4 @@
-v {xschem version=3.4.5 file_version=1.2
+v {xschem version=3.0.0 file_version=1.2
 
 * Copyright 2022 GlobalFoundries PDK Authors
 *
@@ -15,26 +15,13 @@ v {xschem version=3.4.5 file_version=1.2
 * limitations under the License.
 
 }
-G {}
-K {type=moscap
-format="@spiceprefix@name @pinlist @model c_width=@W c_length=@L m=@m"
-template="name=C1
-W=1e-6
-L=1e-6
-model=cap_nmos_03v3
-spiceprefix=X
-m=1"
+K {type=subcircuit
+format="@name @pinlist @symname"
+template="name=x1"
 }
-V {}
-S {}
-E {}
-L 4 0 10 0 30 {}
-L 4 0 -30 0 -5 {}
-L 4 -15 -5 15 -5 {}
-B 4 -15 5 15 10 {}
-B 5 -2.5 -32.5 2.5 -27.5 {name=G dir=inout propag=1 pinnumber=2}
-B 5 -2.5 27.5 2.5 32.5 {name=B dir=inout propag=0 pinnumber=1}
-T {@m * @W / @L} 20 6.25 0 0 0.2 0.2 {layer=13}
-T {@model} 20 -11.25 0 0 0.2 0.2 {}
-T {@spiceprefix@name} 20 -28.75 0 0 0.2 0.2 {}
-T {PW} -25 12.5 0 0 0.2 0.2 { layer=4}
+T {@symname} -76.5 -6 0 0 0.3 0.3 {}
+T {@name} 135 -22 0 0 0.2 0.2 {}
+L 4 -130 -10 130 -10 {}
+L 4 -130 10 130 10 {}
+L 4 -130 -10 -130 10 {}
+L 4 130 -10 130 10 {}

--- a/cells/xschem/tests/test_diode_pd2nw_03v3.sch
+++ b/cells/xschem/tests/test_diode_pd2nw_03v3.sch
@@ -20,33 +20,16 @@ K {}
 V {}
 S {}
 E {}
-B 2 580 -540 1170 -80 {flags=graph
-y1=-0.0067
-y2=0
+B 2 750 -540 1340 -80 {flags=graph
+y1=-2.7e-06
+y2=2e-13
 ypos1=0
 ypos2=2
 divy=5
 subdivy=1
-unity=m
-x1=0
-x2=3.3
-divx=5
-subdivx=1
-node=i(vp)
-color=4
-
-unitx=1
-dataset=-1}
-B 2 580 -1000 1170 -540 {flags=graph
-y1=-0
-y2=500
-ypos1=0
-ypos2=2
-divy=5
-subdivy=1
-unity=1
-x1=0
-x2=3.3
+unity=u
+x1=-0.0251239
+x2=0.934876
 divx=5
 subdivx=1
 
@@ -54,48 +37,46 @@ subdivx=1
 
 unitx=1
 dataset=-1
+
 color=4
-node="\\"resistance; p i(vp) / -1 *\\""}
-N 130 -490 130 -440 {
+node=i(vp)}
+N 230 -470 230 -420 {
 lab=P}
-N 80 -410 110 -410 {
-lab=B}
-N 130 -380 130 -310 {
-lab=M}
-C {devices/code_shown.sym} 20 -160 0 0 {name=MODELS only_toplevel=true
+N 230 -360 230 -290 {
+lab=GND}
+N 230 -490 230 -470 {
+lab=P}
+C {devices/code_shown.sym} 30 -200 0 0 {name=MODELS only_toplevel=true
 format="tcleval( @value )"
 value="
 .include $::180MCU_MODELS/design.ngspice
 .lib $::180MCU_MODELS/sm141064.ngspice typical
 .lib $::180MCU_MODELS/sm141064.ngspice res_typical
+.lib $::180MCU_MODELS/sm141064.ngspice moscap_typical
+.lib $::180MCU_MODELS/sm141064.ngspice diode_typical
 * .lib $::180MCU_MODELS/sm141064.ngspice res_statistical
 "}
-C {devices/lab_pin.sym} 130 -490 0 0 {name=l2 sig_type=std_logic lab=P}
-C {devices/lab_pin.sym} 130 -310 0 0 {name=l3 sig_type=std_logic lab=M}
-C {devices/lab_pin.sym} 80 -410 0 0 {name=l4 sig_type=std_logic lab=B}
-C {devices/code_shown.sym} 300 -450 0 0 {name=NGSPICE only_toplevel=true
+C {devices/code_shown.sym} 390 -450 0 0 {name=NGSPICE only_toplevel=true
 value="
 vp p 0 0
-vm m 0 0
-vb b 0 3.3
-
 .control
 save all
-dc vp 0 3.3 0.01
-write test_ppolyf_u.raw
+dc vp -0.4 0.8 0.001
+write test_diode_pd2nw_03v3.raw
 .endc
 "}
 C {devices/title.sym} 160 -30 0 0 {name=l5 author="GlobalFoundries PDK Authors"}
-C {devices/launcher.sym} 65 -645 0 0 {name=h1
+C {devices/launcher.sym} 185 -635 0 0 {name=h1
 descr="Click left mouse button here with control key
 pressed to load/unload waveforms in graph."
 tclcommand="
 xschem raw_read $netlist_dir/[file tail [file rootname [xschem get current_name]]].raw
 "
 }
-C {symbols/ppolyf_u.sym} 130 -410 0 0 {name=R1
-W=1e-6
-L=1e-6
-model=ppolyf_u
-spiceprefix=X
+C {devices/gnd.sym} 230 -290 0 0 {name=l2 lab=GND}
+C {devices/lab_pin.sym} 230 -490 0 1 {name=l3 sig_type=std_logic lab=P}
+C {symbols/diode_pd2nw_03v3.sym} 230 -390 0 0 {name=D1
+model=diode_pd2nw_03v3
+r_w=1u
+r_l=1u
 m=1}

--- a/cells/xschem/tests/test_diode_pd2nw_03v3.sym
+++ b/cells/xschem/tests/test_diode_pd2nw_03v3.sym
@@ -1,4 +1,4 @@
-v {xschem version=3.4.5 file_version=1.2
+v {xschem version=3.0.0 file_version=1.2
 
 * Copyright 2022 GlobalFoundries PDK Authors
 *
@@ -15,26 +15,13 @@ v {xschem version=3.4.5 file_version=1.2
 * limitations under the License.
 
 }
-G {}
-K {type=moscap
-format="@spiceprefix@name @pinlist @model c_width=@W c_length=@L m=@m"
-template="name=C1
-W=1e-6
-L=1e-6
-model=cap_nmos_03v3
-spiceprefix=X
-m=1"
+K {type=subcircuit
+format="@name @pinlist @symname"
+template="name=x1"
 }
-V {}
-S {}
-E {}
-L 4 0 10 0 30 {}
-L 4 0 -30 0 -5 {}
-L 4 -15 -5 15 -5 {}
-B 4 -15 5 15 10 {}
-B 5 -2.5 -32.5 2.5 -27.5 {name=G dir=inout propag=1 pinnumber=2}
-B 5 -2.5 27.5 2.5 32.5 {name=B dir=inout propag=0 pinnumber=1}
-T {@m * @W / @L} 20 6.25 0 0 0.2 0.2 {layer=13}
-T {@model} 20 -11.25 0 0 0.2 0.2 {}
-T {@spiceprefix@name} 20 -28.75 0 0 0.2 0.2 {}
-T {PW} -25 12.5 0 0 0.2 0.2 { layer=4}
+T {@symname} -76.5 -6 0 0 0.3 0.3 {}
+T {@name} 135 -22 0 0 0.2 0.2 {}
+L 4 -130 -10 130 -10 {}
+L 4 -130 10 130 10 {}
+L 4 -130 -10 -130 10 {}
+L 4 130 -10 130 10 {}

--- a/cells/xschem/tests/test_diode_pd2nw_06v0.sch
+++ b/cells/xschem/tests/test_diode_pd2nw_06v0.sch
@@ -20,33 +20,16 @@ K {}
 V {}
 S {}
 E {}
-B 2 580 -540 1170 -80 {flags=graph
-y1=-0.0067
-y2=0
+B 2 750 -540 1340 -80 {flags=graph
+y1=-2e-06
+y2=2.6e-14
 ypos1=0
 ypos2=2
 divy=5
 subdivy=1
-unity=m
-x1=0
-x2=3.3
-divx=5
-subdivx=1
-node=i(vp)
-color=4
-
-unitx=1
-dataset=-1}
-B 2 580 -1000 1170 -540 {flags=graph
-y1=-0
-y2=500
-ypos1=0
-ypos2=2
-divy=5
-subdivy=1
-unity=1
-x1=0
-x2=3.3
+unity=u
+x1=-0.4
+x2=0.8
 divx=5
 subdivx=1
 
@@ -54,48 +37,46 @@ subdivx=1
 
 unitx=1
 dataset=-1
+
 color=4
-node="\\"resistance; p i(vp) / -1 *\\""}
-N 130 -490 130 -440 {
+node=i(vp)}
+N 230 -470 230 -420 {
 lab=P}
-N 80 -410 110 -410 {
-lab=B}
-N 130 -380 130 -310 {
-lab=M}
-C {devices/code_shown.sym} 20 -160 0 0 {name=MODELS only_toplevel=true
+N 230 -360 230 -290 {
+lab=GND}
+N 230 -490 230 -470 {
+lab=P}
+C {devices/code_shown.sym} 30 -200 0 0 {name=MODELS only_toplevel=true
 format="tcleval( @value )"
 value="
 .include $::180MCU_MODELS/design.ngspice
 .lib $::180MCU_MODELS/sm141064.ngspice typical
 .lib $::180MCU_MODELS/sm141064.ngspice res_typical
+.lib $::180MCU_MODELS/sm141064.ngspice moscap_typical
+.lib $::180MCU_MODELS/sm141064.ngspice diode_typical
 * .lib $::180MCU_MODELS/sm141064.ngspice res_statistical
 "}
-C {devices/lab_pin.sym} 130 -490 0 0 {name=l2 sig_type=std_logic lab=P}
-C {devices/lab_pin.sym} 130 -310 0 0 {name=l3 sig_type=std_logic lab=M}
-C {devices/lab_pin.sym} 80 -410 0 0 {name=l4 sig_type=std_logic lab=B}
-C {devices/code_shown.sym} 300 -450 0 0 {name=NGSPICE only_toplevel=true
+C {devices/code_shown.sym} 390 -450 0 0 {name=NGSPICE only_toplevel=true
 value="
 vp p 0 0
-vm m 0 0
-vb b 0 3.3
-
 .control
 save all
-dc vp 0 3.3 0.01
-write test_ppolyf_u.raw
+dc vp -0.4 0.8 0.001
+write test_diode_pd2nw_06v0.raw
 .endc
 "}
 C {devices/title.sym} 160 -30 0 0 {name=l5 author="GlobalFoundries PDK Authors"}
-C {devices/launcher.sym} 65 -645 0 0 {name=h1
+C {devices/launcher.sym} 185 -635 0 0 {name=h1
 descr="Click left mouse button here with control key
 pressed to load/unload waveforms in graph."
 tclcommand="
 xschem raw_read $netlist_dir/[file tail [file rootname [xschem get current_name]]].raw
 "
 }
-C {symbols/ppolyf_u.sym} 130 -410 0 0 {name=R1
-W=1e-6
-L=1e-6
-model=ppolyf_u
-spiceprefix=X
+C {devices/gnd.sym} 230 -290 0 0 {name=l2 lab=GND}
+C {devices/lab_pin.sym} 230 -490 0 1 {name=l3 sig_type=std_logic lab=P}
+C {symbols/diode_pd2nw_06v0.sym} 230 -390 0 0 {name=D1
+model=diode_pd2nw_06v0
+r_w=1u
+r_l=1u
 m=1}

--- a/cells/xschem/tests/test_diode_pd2nw_06v0.sym
+++ b/cells/xschem/tests/test_diode_pd2nw_06v0.sym
@@ -1,4 +1,4 @@
-v {xschem version=3.4.5 file_version=1.2
+v {xschem version=3.0.0 file_version=1.2
 
 * Copyright 2022 GlobalFoundries PDK Authors
 *
@@ -15,26 +15,13 @@ v {xschem version=3.4.5 file_version=1.2
 * limitations under the License.
 
 }
-G {}
-K {type=moscap
-format="@spiceprefix@name @pinlist @model c_width=@W c_length=@L m=@m"
-template="name=C1
-W=1e-6
-L=1e-6
-model=cap_nmos_03v3
-spiceprefix=X
-m=1"
+K {type=subcircuit
+format="@name @pinlist @symname"
+template="name=x1"
 }
-V {}
-S {}
-E {}
-L 4 0 10 0 30 {}
-L 4 0 -30 0 -5 {}
-L 4 -15 -5 15 -5 {}
-B 4 -15 5 15 10 {}
-B 5 -2.5 -32.5 2.5 -27.5 {name=G dir=inout propag=1 pinnumber=2}
-B 5 -2.5 27.5 2.5 32.5 {name=B dir=inout propag=0 pinnumber=1}
-T {@m * @W / @L} 20 6.25 0 0 0.2 0.2 {layer=13}
-T {@model} 20 -11.25 0 0 0.2 0.2 {}
-T {@spiceprefix@name} 20 -28.75 0 0 0.2 0.2 {}
-T {PW} -25 12.5 0 0 0.2 0.2 { layer=4}
+T {@symname} -76.5 -6 0 0 0.3 0.3 {}
+T {@name} 135 -22 0 0 0.2 0.2 {}
+L 4 -130 -10 130 -10 {}
+L 4 -130 10 130 10 {}
+L 4 -130 -10 -130 10 {}
+L 4 130 -10 130 10 {}

--- a/cells/xschem/tests/test_nfet_06v0_dss.sch
+++ b/cells/xschem/tests/test_nfet_06v0_dss.sch
@@ -21,81 +21,71 @@ V {}
 S {}
 E {}
 B 2 580 -540 1170 -80 {flags=graph
-y1=-0.0067
-y2=0
+y1=-0.00021
+y2=2.1e-20
 ypos1=0
 ypos2=2
 divy=5
 subdivy=1
-unity=m
+unity=u
 x1=0
-x2=3.3
+x2=6
 divx=5
 subdivx=1
-node=i(vp)
+node=i(vd)
 color=4
 
 unitx=1
 dataset=-1}
-B 2 580 -1000 1170 -540 {flags=graph
-y1=-0
-y2=500
-ypos1=0
-ypos2=2
-divy=5
-subdivy=1
-unity=1
-x1=0
-x2=3.3
-divx=5
-subdivx=1
-
-
-
-unitx=1
-dataset=-1
-color=4
-node="\\"resistance; p i(vp) / -1 *\\""}
+N 50 -410 90 -410 {
+lab=G}
 N 130 -490 130 -440 {
-lab=P}
-N 80 -410 110 -410 {
+lab=D}
+N 130 -410 230 -410 {
 lab=B}
 N 130 -380 130 -310 {
-lab=M}
+lab=S}
 C {devices/code_shown.sym} 20 -160 0 0 {name=MODELS only_toplevel=true
 format="tcleval( @value )"
 value="
 .include $::180MCU_MODELS/design.ngspice
 .lib $::180MCU_MODELS/sm141064.ngspice typical
-.lib $::180MCU_MODELS/sm141064.ngspice res_typical
-* .lib $::180MCU_MODELS/sm141064.ngspice res_statistical
 "}
-C {devices/lab_pin.sym} 130 -490 0 0 {name=l2 sig_type=std_logic lab=P}
-C {devices/lab_pin.sym} 130 -310 0 0 {name=l3 sig_type=std_logic lab=M}
-C {devices/lab_pin.sym} 80 -410 0 0 {name=l4 sig_type=std_logic lab=B}
+C {devices/lab_pin.sym} 50 -410 0 0 {name=l1 sig_type=std_logic lab=G}
+C {devices/lab_pin.sym} 130 -490 0 0 {name=l2 sig_type=std_logic lab=D}
+C {devices/lab_pin.sym} 130 -310 0 0 {name=l3 sig_type=std_logic lab=S}
+C {devices/lab_pin.sym} 230 -410 0 1 {name=l4 sig_type=std_logic lab=B}
 C {devices/code_shown.sym} 300 -450 0 0 {name=NGSPICE only_toplevel=true
 value="
-vp p 0 0
-vm m 0 0
-vb b 0 3.3
-
+vg g 0 0
+vd d 0 0
+vs s 0 0
+vb b 0 0
 .control
 save all
-dc vp 0 3.3 0.01
-write test_ppolyf_u.raw
+dc vd 0 6 0.01 vg 0 6 1
+write test_nfet_06v0_dss.raw
 .endc
 "}
 C {devices/title.sym} 160 -30 0 0 {name=l5 author="GlobalFoundries PDK Authors"}
-C {devices/launcher.sym} 65 -645 0 0 {name=h1
+C {symbols/nfet_06v0_dss.sym} 110 -410 0 0 {name=M1
+L=0.70u
+W=0.30u
+nf=1
+mult=1
+ad="'int((nf+1)/2) * W/nf * 0.18u'"
+pd="'2*int((nf+1)/2) * (W/nf + 0.18u)'"
+as="'int((nf+2)/2) * W/nf * 0.18u'"
+ps="'2*int((nf+2)/2) * (W/nf + 0.18u)'"
+nrd="'0.18u / W'" nrs="'0.18u / W'"
+sa=0 sb=0 sd=0
+model=nfet_06v0_dss
+spiceprefix=X
+}
+C {devices/launcher.sym} 185 -635 0 0 {name=h1
 descr="Click left mouse button here with control key
 pressed to load/unload waveforms in graph."
 tclcommand="
 xschem raw_read $netlist_dir/[file tail [file rootname [xschem get current_name]]].raw
 "
 }
-C {symbols/ppolyf_u.sym} 130 -410 0 0 {name=R1
-W=1e-6
-L=1e-6
-model=ppolyf_u
-spiceprefix=X
-m=1}

--- a/cells/xschem/tests/test_nfet_06v0_dss.sym
+++ b/cells/xschem/tests/test_nfet_06v0_dss.sym
@@ -1,4 +1,4 @@
-v {xschem version=3.4.5 file_version=1.2
+v {xschem version=3.0.0 file_version=1.2
 
 * Copyright 2022 GlobalFoundries PDK Authors
 *
@@ -15,26 +15,13 @@ v {xschem version=3.4.5 file_version=1.2
 * limitations under the License.
 
 }
-G {}
-K {type=moscap
-format="@spiceprefix@name @pinlist @model c_width=@W c_length=@L m=@m"
-template="name=C1
-W=1e-6
-L=1e-6
-model=cap_nmos_03v3
-spiceprefix=X
-m=1"
+K {type=subcircuit
+format="@name @pinlist @symname"
+template="name=x1"
 }
-V {}
-S {}
-E {}
-L 4 0 10 0 30 {}
-L 4 0 -30 0 -5 {}
-L 4 -15 -5 15 -5 {}
-B 4 -15 5 15 10 {}
-B 5 -2.5 -32.5 2.5 -27.5 {name=G dir=inout propag=1 pinnumber=2}
-B 5 -2.5 27.5 2.5 32.5 {name=B dir=inout propag=0 pinnumber=1}
-T {@m * @W / @L} 20 6.25 0 0 0.2 0.2 {layer=13}
-T {@model} 20 -11.25 0 0 0.2 0.2 {}
-T {@spiceprefix@name} 20 -28.75 0 0 0.2 0.2 {}
-T {PW} -25 12.5 0 0 0.2 0.2 { layer=4}
+T {@symname} -76.5 -6 0 0 0.3 0.3 {}
+T {@name} 135 -22 0 0 0.2 0.2 {}
+L 4 -130 -10 130 -10 {}
+L 4 -130 10 130 10 {}
+L 4 -130 -10 -130 10 {}
+L 4 130 -10 130 10 {}

--- a/cells/xschem/tests/test_nfet_10v0_asym.sch
+++ b/cells/xschem/tests/test_nfet_10v0_asym.sch
@@ -21,81 +21,72 @@ V {}
 S {}
 E {}
 B 2 580 -540 1170 -80 {flags=graph
-y1=-0.0067
-y2=0
+y1=-0.014
+y2=1.8e-19
 ypos1=0
 ypos2=2
 divy=5
 subdivy=1
 unity=m
 x1=0
-x2=3.3
+x2=6
 divx=5
 subdivx=1
-node=i(vp)
+node=i(vd)
 color=4
 
 unitx=1
 dataset=-1}
-B 2 580 -1000 1170 -540 {flags=graph
-y1=-0
-y2=500
-ypos1=0
-ypos2=2
-divy=5
-subdivy=1
-unity=1
-x1=0
-x2=3.3
-divx=5
-subdivx=1
-
-
-
-unitx=1
-dataset=-1
-color=4
-node="\\"resistance; p i(vp) / -1 *\\""}
+N 50 -410 90 -410 {
+lab=G}
 N 130 -490 130 -440 {
-lab=P}
-N 80 -410 110 -410 {
+lab=D}
+N 130 -410 230 -410 {
 lab=B}
 N 130 -380 130 -310 {
-lab=M}
+lab=S}
 C {devices/code_shown.sym} 20 -160 0 0 {name=MODELS only_toplevel=true
 format="tcleval( @value )"
 value="
 .include $::180MCU_MODELS/design.ngspice
 .lib $::180MCU_MODELS/sm141064.ngspice typical
-.lib $::180MCU_MODELS/sm141064.ngspice res_typical
-* .lib $::180MCU_MODELS/sm141064.ngspice res_statistical
+.lib $::180MCU_MODELS/smbb000149.ngspice typical
 "}
-C {devices/lab_pin.sym} 130 -490 0 0 {name=l2 sig_type=std_logic lab=P}
-C {devices/lab_pin.sym} 130 -310 0 0 {name=l3 sig_type=std_logic lab=M}
-C {devices/lab_pin.sym} 80 -410 0 0 {name=l4 sig_type=std_logic lab=B}
-C {devices/code_shown.sym} 300 -450 0 0 {name=NGSPICE only_toplevel=true
+C {devices/lab_pin.sym} 50 -410 0 0 {name=l1 sig_type=std_logic lab=G}
+C {devices/lab_pin.sym} 130 -490 0 0 {name=l2 sig_type=std_logic lab=D}
+C {devices/lab_pin.sym} 130 -310 0 0 {name=l3 sig_type=std_logic lab=S}
+C {devices/lab_pin.sym} 230 -410 0 1 {name=l4 sig_type=std_logic lab=B}
+C {devices/code_shown.sym} 260 -450 0 0 {name=NGSPICE only_toplevel=true
 value="
-vp p 0 0
-vm m 0 0
-vb b 0 3.3
-
+vg g 0 0
+vd d 0 0
+vs s 0 0
+vb b 0 0
 .control
 save all
-dc vp 0 3.3 0.01
-write test_ppolyf_u.raw
+dc vd 0 6 0.01 vg 0 6 1
+write test_nfet_10v0_asym.raw
 .endc
 "}
 C {devices/title.sym} 160 -30 0 0 {name=l5 author="GlobalFoundries PDK Authors"}
-C {devices/launcher.sym} 65 -645 0 0 {name=h1
+C {devices/launcher.sym} 185 -635 0 0 {name=h1
 descr="Click left mouse button here with control key
 pressed to load/unload waveforms in graph."
 tclcommand="
 xschem raw_read $netlist_dir/[file tail [file rootname [xschem get current_name]]].raw
 "
 }
-C {symbols/ppolyf_u.sym} 130 -410 0 0 {name=R1
-W=1e-6
-L=1e-6
-model=ppolyf_u
+C {symbols/nfet_10v0_asym.sym} 110 -410 0 0 {name=M1
+L=0.60u
+W=25u
+nf=1
+m=1
+ad="'W * 1.48u'"
+pd="'2 * (W + 1.48u)'"
+as="'W * 0.48u'"
+ps="'2 * (W + 0.48u)'"
+nrd=0 nrs=0
+sa=0 sb=0 sd=0
+model=nfet_10v0_asym
 spiceprefix=X
-m=1}
+}

--- a/cells/xschem/tests/test_nfet_10v0_asym.sym
+++ b/cells/xschem/tests/test_nfet_10v0_asym.sym
@@ -1,4 +1,4 @@
-v {xschem version=3.4.5 file_version=1.2
+v {xschem version=3.0.0 file_version=1.2
 
 * Copyright 2022 GlobalFoundries PDK Authors
 *
@@ -15,26 +15,13 @@ v {xschem version=3.4.5 file_version=1.2
 * limitations under the License.
 
 }
-G {}
-K {type=moscap
-format="@spiceprefix@name @pinlist @model c_width=@W c_length=@L m=@m"
-template="name=C1
-W=1e-6
-L=1e-6
-model=cap_nmos_03v3
-spiceprefix=X
-m=1"
+K {type=subcircuit
+format="@name @pinlist @symname"
+template="name=x1"
 }
-V {}
-S {}
-E {}
-L 4 0 10 0 30 {}
-L 4 0 -30 0 -5 {}
-L 4 -15 -5 15 -5 {}
-B 4 -15 5 15 10 {}
-B 5 -2.5 -32.5 2.5 -27.5 {name=G dir=inout propag=1 pinnumber=2}
-B 5 -2.5 27.5 2.5 32.5 {name=B dir=inout propag=0 pinnumber=1}
-T {@m * @W / @L} 20 6.25 0 0 0.2 0.2 {layer=13}
-T {@model} 20 -11.25 0 0 0.2 0.2 {}
-T {@spiceprefix@name} 20 -28.75 0 0 0.2 0.2 {}
-T {PW} -25 12.5 0 0 0.2 0.2 { layer=4}
+T {@symname} -76.5 -6 0 0 0.3 0.3 {}
+T {@name} 135 -22 0 0 0.2 0.2 {}
+L 4 -130 -10 130 -10 {}
+L 4 -130 10 130 10 {}
+L 4 -130 -10 -130 10 {}
+L 4 130 -10 130 10 {}

--- a/cells/xschem/tests/test_npn_00p54x02p00.sch
+++ b/cells/xschem/tests/test_npn_00p54x02p00.sch
@@ -20,33 +20,16 @@ K {}
 V {}
 S {}
 E {}
-B 2 580 -540 1170 -80 {flags=graph
-y1=-0.0067
-y2=0
+B 2 750 -540 1340 -80 {flags=graph
+y1=-1.5e-05
+y2=-9.4e-12
 ypos1=0
 ypos2=2
 divy=5
 subdivy=1
-unity=m
-x1=0
-x2=3.3
-divx=5
-subdivx=1
-node=i(vp)
-color=4
-
-unitx=1
-dataset=-1}
-B 2 580 -1000 1170 -540 {flags=graph
-y1=-0
-y2=500
-ypos1=0
-ypos2=2
-divy=5
-subdivy=1
-unity=1
-x1=0
-x2=3.3
+unity=u
+x1=0.4
+x2=0.8
 divx=5
 subdivx=1
 
@@ -54,48 +37,68 @@ subdivx=1
 
 unitx=1
 dataset=-1
+
 color=4
-node="\\"resistance; p i(vp) / -1 *\\""}
-N 130 -490 130 -440 {
-lab=P}
-N 80 -410 110 -410 {
+node=i(vc)}
+B 2 750 -1000 1340 -540 {flags=graph
+y1=2.3
+y2=9.2
+ypos1=0
+ypos2=2
+divy=5
+subdivy=1
+unity=1
+x1=0.4
+x2=0.8
+divx=5
+subdivx=1
+
+
+
+unitx=1
+dataset=-1
+
+color=4
+node="\\"Current_gain;i(vc) i(vb) /\\""}
+N 210 -390 210 -300 {
+lab=GND}
+N 130 -390 170 -390 {
 lab=B}
-N 130 -380 130 -310 {
-lab=M}
-C {devices/code_shown.sym} 20 -160 0 0 {name=MODELS only_toplevel=true
+N 210 -460 210 -420 {
+lab=C}
+C {devices/code_shown.sym} 30 -200 0 0 {name=MODELS only_toplevel=true
 format="tcleval( @value )"
 value="
 .include $::180MCU_MODELS/design.ngspice
 .lib $::180MCU_MODELS/sm141064.ngspice typical
 .lib $::180MCU_MODELS/sm141064.ngspice res_typical
+.lib $::180MCU_MODELS/sm141064.ngspice moscap_typical
+.lib $::180MCU_MODELS/sm141064.ngspice bjt_typical
 * .lib $::180MCU_MODELS/sm141064.ngspice res_statistical
 "}
-C {devices/lab_pin.sym} 130 -490 0 0 {name=l2 sig_type=std_logic lab=P}
-C {devices/lab_pin.sym} 130 -310 0 0 {name=l3 sig_type=std_logic lab=M}
-C {devices/lab_pin.sym} 80 -410 0 0 {name=l4 sig_type=std_logic lab=B}
-C {devices/code_shown.sym} 300 -450 0 0 {name=NGSPICE only_toplevel=true
+C {devices/code_shown.sym} 390 -450 0 0 {name=NGSPICE only_toplevel=true
 value="
-vp p 0 0
-vm m 0 0
-vb b 0 3.3
+vc c 0 dc 3.3
+vb b 0 0
 
 .control
+dc vb 0.4 0.8 0.001
 save all
-dc vp 0 3.3 0.01
-write test_ppolyf_u.raw
+write test_npn_00p54x02p00.raw
 .endc
 "}
 C {devices/title.sym} 160 -30 0 0 {name=l5 author="GlobalFoundries PDK Authors"}
-C {devices/launcher.sym} 65 -645 0 0 {name=h1
+C {devices/launcher.sym} 185 -635 0 0 {name=h1
 descr="Click left mouse button here with control key
 pressed to load/unload waveforms in graph."
 tclcommand="
 xschem raw_read $netlist_dir/[file tail [file rootname [xschem get current_name]]].raw
 "
 }
-C {symbols/ppolyf_u.sym} 130 -410 0 0 {name=R1
-W=1e-6
-L=1e-6
-model=ppolyf_u
+C {symbols/npn_00p54x02p00.sym} 190 -390 0 0 {name=Q1
+model=npn_00p54x02p00
 spiceprefix=X
 m=1}
+C {devices/gnd.sym} 210 -300 0 0 {name=l1 lab=GND}
+C {devices/lab_pin.sym} 130 -390 0 0 {name=l2 sig_type=std_logic lab=B}
+C {devices/lab_pin.sym} 210 -460 0 0 {name=l3 sig_type=std_logic lab=C}

--- a/cells/xschem/tests/test_npn_00p54x02p00.sym
+++ b/cells/xschem/tests/test_npn_00p54x02p00.sym
@@ -1,4 +1,4 @@
-v {xschem version=3.4.5 file_version=1.2
+v {xschem version=3.0.0 file_version=1.2
 
 * Copyright 2022 GlobalFoundries PDK Authors
 *
@@ -15,26 +15,13 @@ v {xschem version=3.4.5 file_version=1.2
 * limitations under the License.
 
 }
-G {}
-K {type=moscap
-format="@spiceprefix@name @pinlist @model c_width=@W c_length=@L m=@m"
-template="name=C1
-W=1e-6
-L=1e-6
-model=cap_nmos_03v3
-spiceprefix=X
-m=1"
+K {type=subcircuit
+format="@name @pinlist @symname"
+template="name=x1"
 }
-V {}
-S {}
-E {}
-L 4 0 10 0 30 {}
-L 4 0 -30 0 -5 {}
-L 4 -15 -5 15 -5 {}
-B 4 -15 5 15 10 {}
-B 5 -2.5 -32.5 2.5 -27.5 {name=G dir=inout propag=1 pinnumber=2}
-B 5 -2.5 27.5 2.5 32.5 {name=B dir=inout propag=0 pinnumber=1}
-T {@m * @W / @L} 20 6.25 0 0 0.2 0.2 {layer=13}
-T {@model} 20 -11.25 0 0 0.2 0.2 {}
-T {@spiceprefix@name} 20 -28.75 0 0 0.2 0.2 {}
-T {PW} -25 12.5 0 0 0.2 0.2 { layer=4}
+T {@symname} -76.5 -6 0 0 0.3 0.3 {}
+T {@name} 135 -22 0 0 0.2 0.2 {}
+L 4 -130 -10 130 -10 {}
+L 4 -130 10 130 10 {}
+L 4 -130 -10 -130 10 {}
+L 4 130 -10 130 10 {}

--- a/cells/xschem/tests/test_npn_00p54x04p00.sch
+++ b/cells/xschem/tests/test_npn_00p54x04p00.sch
@@ -20,33 +20,16 @@ K {}
 V {}
 S {}
 E {}
-B 2 580 -540 1170 -80 {flags=graph
-y1=-0.0067
-y2=0
+B 2 750 -540 1340 -80 {flags=graph
+y1=-2.7e-05
+y2=-1.1e-11
 ypos1=0
 ypos2=2
 divy=5
 subdivy=1
-unity=m
-x1=0
-x2=3.3
-divx=5
-subdivx=1
-node=i(vp)
-color=4
-
-unitx=1
-dataset=-1}
-B 2 580 -1000 1170 -540 {flags=graph
-y1=-0
-y2=500
-ypos1=0
-ypos2=2
-divy=5
-subdivy=1
-unity=1
-x1=0
-x2=3.3
+unity=u
+x1=0.4
+x2=0.8
 divx=5
 subdivx=1
 
@@ -54,48 +37,68 @@ subdivx=1
 
 unitx=1
 dataset=-1
+
 color=4
-node="\\"resistance; p i(vp) / -1 *\\""}
-N 130 -490 130 -440 {
-lab=P}
-N 80 -410 110 -410 {
+node=i(vc)}
+B 2 750 -1000 1340 -540 {flags=graph
+y1=1.9
+y2=8.3
+ypos1=0
+ypos2=2
+divy=5
+subdivy=1
+unity=1
+x1=0.4
+x2=0.8
+divx=5
+subdivx=1
+
+
+
+unitx=1
+dataset=-1
+
+color=4
+node="\\"Current_gain;i(vc) i(vb) /\\""}
+N 210 -390 210 -300 {
+lab=GND}
+N 130 -390 170 -390 {
 lab=B}
-N 130 -380 130 -310 {
-lab=M}
-C {devices/code_shown.sym} 20 -160 0 0 {name=MODELS only_toplevel=true
+N 210 -460 210 -420 {
+lab=C}
+C {devices/code_shown.sym} 30 -200 0 0 {name=MODELS only_toplevel=true
 format="tcleval( @value )"
 value="
 .include $::180MCU_MODELS/design.ngspice
 .lib $::180MCU_MODELS/sm141064.ngspice typical
 .lib $::180MCU_MODELS/sm141064.ngspice res_typical
+.lib $::180MCU_MODELS/sm141064.ngspice moscap_typical
+.lib $::180MCU_MODELS/sm141064.ngspice bjt_typical
 * .lib $::180MCU_MODELS/sm141064.ngspice res_statistical
 "}
-C {devices/lab_pin.sym} 130 -490 0 0 {name=l2 sig_type=std_logic lab=P}
-C {devices/lab_pin.sym} 130 -310 0 0 {name=l3 sig_type=std_logic lab=M}
-C {devices/lab_pin.sym} 80 -410 0 0 {name=l4 sig_type=std_logic lab=B}
-C {devices/code_shown.sym} 300 -450 0 0 {name=NGSPICE only_toplevel=true
+C {devices/code_shown.sym} 390 -450 0 0 {name=NGSPICE only_toplevel=true
 value="
-vp p 0 0
-vm m 0 0
-vb b 0 3.3
+vc c 0 dc 3.3
+vb b 0 0
 
 .control
+dc vb 0.4 0.8 0.001
 save all
-dc vp 0 3.3 0.01
-write test_ppolyf_u.raw
+write test_npn_00p54x04p00.raw
 .endc
 "}
 C {devices/title.sym} 160 -30 0 0 {name=l5 author="GlobalFoundries PDK Authors"}
-C {devices/launcher.sym} 65 -645 0 0 {name=h1
+C {devices/launcher.sym} 185 -635 0 0 {name=h1
 descr="Click left mouse button here with control key
 pressed to load/unload waveforms in graph."
 tclcommand="
 xschem raw_read $netlist_dir/[file tail [file rootname [xschem get current_name]]].raw
 "
 }
-C {symbols/ppolyf_u.sym} 130 -410 0 0 {name=R1
-W=1e-6
-L=1e-6
-model=ppolyf_u
+C {symbols/npn_00p54x04p00.sym} 190 -390 0 0 {name=Q1
+model=npn_00p54x04p00
 spiceprefix=X
 m=1}
+C {devices/gnd.sym} 210 -300 0 0 {name=l1 lab=GND}
+C {devices/lab_pin.sym} 130 -390 0 0 {name=l2 sig_type=std_logic lab=B}
+C {devices/lab_pin.sym} 210 -460 0 0 {name=l3 sig_type=std_logic lab=C}

--- a/cells/xschem/tests/test_npn_00p54x04p00.sym
+++ b/cells/xschem/tests/test_npn_00p54x04p00.sym
@@ -1,4 +1,4 @@
-v {xschem version=3.4.5 file_version=1.2
+v {xschem version=3.0.0 file_version=1.2
 
 * Copyright 2022 GlobalFoundries PDK Authors
 *
@@ -15,26 +15,13 @@ v {xschem version=3.4.5 file_version=1.2
 * limitations under the License.
 
 }
-G {}
-K {type=moscap
-format="@spiceprefix@name @pinlist @model c_width=@W c_length=@L m=@m"
-template="name=C1
-W=1e-6
-L=1e-6
-model=cap_nmos_03v3
-spiceprefix=X
-m=1"
+K {type=subcircuit
+format="@name @pinlist @symname"
+template="name=x1"
 }
-V {}
-S {}
-E {}
-L 4 0 10 0 30 {}
-L 4 0 -30 0 -5 {}
-L 4 -15 -5 15 -5 {}
-B 4 -15 5 15 10 {}
-B 5 -2.5 -32.5 2.5 -27.5 {name=G dir=inout propag=1 pinnumber=2}
-B 5 -2.5 27.5 2.5 32.5 {name=B dir=inout propag=0 pinnumber=1}
-T {@m * @W / @L} 20 6.25 0 0 0.2 0.2 {layer=13}
-T {@model} 20 -11.25 0 0 0.2 0.2 {}
-T {@spiceprefix@name} 20 -28.75 0 0 0.2 0.2 {}
-T {PW} -25 12.5 0 0 0.2 0.2 { layer=4}
+T {@symname} -76.5 -6 0 0 0.3 0.3 {}
+T {@name} 135 -22 0 0 0.2 0.2 {}
+L 4 -130 -10 130 -10 {}
+L 4 -130 10 130 10 {}
+L 4 -130 -10 -130 10 {}
+L 4 130 -10 130 10 {}

--- a/cells/xschem/tests/test_npn_00p54x08p00.sch
+++ b/cells/xschem/tests/test_npn_00p54x08p00.sch
@@ -20,33 +20,16 @@ K {}
 V {}
 S {}
 E {}
-B 2 580 -540 1170 -80 {flags=graph
-y1=-0.0067
-y2=0
+B 2 750 -540 1340 -80 {flags=graph
+y1=-4.9e-05
+y2=-1.6e-11
 ypos1=0
 ypos2=2
 divy=5
 subdivy=1
-unity=m
-x1=0
-x2=3.3
-divx=5
-subdivx=1
-node=i(vp)
-color=4
-
-unitx=1
-dataset=-1}
-B 2 580 -1000 1170 -540 {flags=graph
-y1=-0
-y2=500
-ypos1=0
-ypos2=2
-divy=5
-subdivy=1
-unity=1
-x1=0
-x2=3.3
+unity=u
+x1=0.4
+x2=0.8
 divx=5
 subdivx=1
 
@@ -54,48 +37,68 @@ subdivx=1
 
 unitx=1
 dataset=-1
+
 color=4
-node="\\"resistance; p i(vp) / -1 *\\""}
-N 130 -490 130 -440 {
-lab=P}
-N 80 -410 110 -410 {
+node=i(vc)}
+B 2 750 -1000 1340 -540 {flags=graph
+y1=1.4
+y2=8.2
+ypos1=0
+ypos2=2
+divy=5
+subdivy=1
+unity=1
+x1=0.4
+x2=0.8
+divx=5
+subdivx=1
+
+
+
+unitx=1
+dataset=-1
+
+color=4
+node="\\"Current_gain;i(vc) i(vb) /\\""}
+N 210 -390 210 -300 {
+lab=GND}
+N 130 -390 170 -390 {
 lab=B}
-N 130 -380 130 -310 {
-lab=M}
-C {devices/code_shown.sym} 20 -160 0 0 {name=MODELS only_toplevel=true
+N 210 -460 210 -420 {
+lab=C}
+C {devices/code_shown.sym} 30 -200 0 0 {name=MODELS only_toplevel=true
 format="tcleval( @value )"
 value="
 .include $::180MCU_MODELS/design.ngspice
 .lib $::180MCU_MODELS/sm141064.ngspice typical
 .lib $::180MCU_MODELS/sm141064.ngspice res_typical
+.lib $::180MCU_MODELS/sm141064.ngspice moscap_typical
+.lib $::180MCU_MODELS/sm141064.ngspice bjt_typical
 * .lib $::180MCU_MODELS/sm141064.ngspice res_statistical
 "}
-C {devices/lab_pin.sym} 130 -490 0 0 {name=l2 sig_type=std_logic lab=P}
-C {devices/lab_pin.sym} 130 -310 0 0 {name=l3 sig_type=std_logic lab=M}
-C {devices/lab_pin.sym} 80 -410 0 0 {name=l4 sig_type=std_logic lab=B}
-C {devices/code_shown.sym} 300 -450 0 0 {name=NGSPICE only_toplevel=true
+C {devices/code_shown.sym} 390 -450 0 0 {name=NGSPICE only_toplevel=true
 value="
-vp p 0 0
-vm m 0 0
-vb b 0 3.3
+vc c 0 dc 3.3
+vb b 0 0
 
 .control
+dc vb 0.4 0.8 0.001
 save all
-dc vp 0 3.3 0.01
-write test_ppolyf_u.raw
+write test_npn_00p54x08p00.raw
 .endc
 "}
 C {devices/title.sym} 160 -30 0 0 {name=l5 author="GlobalFoundries PDK Authors"}
-C {devices/launcher.sym} 65 -645 0 0 {name=h1
+C {devices/launcher.sym} 185 -635 0 0 {name=h1
 descr="Click left mouse button here with control key
 pressed to load/unload waveforms in graph."
 tclcommand="
 xschem raw_read $netlist_dir/[file tail [file rootname [xschem get current_name]]].raw
 "
 }
-C {symbols/ppolyf_u.sym} 130 -410 0 0 {name=R1
-W=1e-6
-L=1e-6
-model=ppolyf_u
+C {symbols/npn_00p54x08p00.sym} 190 -390 0 0 {name=Q1
+model=npn_00p54x08p00
 spiceprefix=X
 m=1}
+C {devices/gnd.sym} 210 -300 0 0 {name=l1 lab=GND}
+C {devices/lab_pin.sym} 130 -390 0 0 {name=l2 sig_type=std_logic lab=B}
+C {devices/lab_pin.sym} 210 -460 0 0 {name=l3 sig_type=std_logic lab=C}

--- a/cells/xschem/tests/test_npn_00p54x08p00.sym
+++ b/cells/xschem/tests/test_npn_00p54x08p00.sym
@@ -1,4 +1,4 @@
-v {xschem version=3.4.5 file_version=1.2
+v {xschem version=3.0.0 file_version=1.2
 
 * Copyright 2022 GlobalFoundries PDK Authors
 *
@@ -15,26 +15,13 @@ v {xschem version=3.4.5 file_version=1.2
 * limitations under the License.
 
 }
-G {}
-K {type=moscap
-format="@spiceprefix@name @pinlist @model c_width=@W c_length=@L m=@m"
-template="name=C1
-W=1e-6
-L=1e-6
-model=cap_nmos_03v3
-spiceprefix=X
-m=1"
+K {type=subcircuit
+format="@name @pinlist @symname"
+template="name=x1"
 }
-V {}
-S {}
-E {}
-L 4 0 10 0 30 {}
-L 4 0 -30 0 -5 {}
-L 4 -15 -5 15 -5 {}
-B 4 -15 5 15 10 {}
-B 5 -2.5 -32.5 2.5 -27.5 {name=G dir=inout propag=1 pinnumber=2}
-B 5 -2.5 27.5 2.5 32.5 {name=B dir=inout propag=0 pinnumber=1}
-T {@m * @W / @L} 20 6.25 0 0 0.2 0.2 {layer=13}
-T {@model} 20 -11.25 0 0 0.2 0.2 {}
-T {@spiceprefix@name} 20 -28.75 0 0 0.2 0.2 {}
-T {PW} -25 12.5 0 0 0.2 0.2 { layer=4}
+T {@symname} -76.5 -6 0 0 0.3 0.3 {}
+T {@name} 135 -22 0 0 0.2 0.2 {}
+L 4 -130 -10 130 -10 {}
+L 4 -130 10 130 10 {}
+L 4 -130 -10 -130 10 {}
+L 4 130 -10 130 10 {}

--- a/cells/xschem/tests/test_npn_00p54x16p00.sch
+++ b/cells/xschem/tests/test_npn_00p54x16p00.sch
@@ -20,33 +20,16 @@ K {}
 V {}
 S {}
 E {}
-B 2 580 -540 1170 -80 {flags=graph
-y1=-0.0067
-y2=0
+B 2 750 -540 1340 -80 {flags=graph
+y1=-9e-05
+y2=-2.7e-11
 ypos1=0
 ypos2=2
 divy=5
 subdivy=1
-unity=m
-x1=0
-x2=3.3
-divx=5
-subdivx=1
-node=i(vp)
-color=4
-
-unitx=1
-dataset=-1}
-B 2 580 -1000 1170 -540 {flags=graph
-y1=-0
-y2=500
-ypos1=0
-ypos2=2
-divy=5
-subdivy=1
-unity=1
-x1=0
-x2=3.3
+unity=u
+x1=0.4
+x2=0.8
 divx=5
 subdivx=1
 
@@ -54,48 +37,68 @@ subdivx=1
 
 unitx=1
 dataset=-1
+
 color=4
-node="\\"resistance; p i(vp) / -1 *\\""}
-N 130 -490 130 -440 {
-lab=P}
-N 80 -410 110 -410 {
+node=i(vc)}
+B 2 750 -1000 1340 -540 {flags=graph
+y1=1.1
+y2=8.2
+ypos1=0
+ypos2=2
+divy=5
+subdivy=1
+unity=1
+x1=0.4
+x2=0.8
+divx=5
+subdivx=1
+
+
+
+unitx=1
+dataset=-1
+
+color=4
+node="\\"Current_gain;i(vc) i(vb) /\\""}
+N 210 -390 210 -300 {
+lab=GND}
+N 130 -390 170 -390 {
 lab=B}
-N 130 -380 130 -310 {
-lab=M}
-C {devices/code_shown.sym} 20 -160 0 0 {name=MODELS only_toplevel=true
+N 210 -460 210 -420 {
+lab=C}
+C {devices/code_shown.sym} 30 -200 0 0 {name=MODELS only_toplevel=true
 format="tcleval( @value )"
 value="
 .include $::180MCU_MODELS/design.ngspice
 .lib $::180MCU_MODELS/sm141064.ngspice typical
 .lib $::180MCU_MODELS/sm141064.ngspice res_typical
+.lib $::180MCU_MODELS/sm141064.ngspice moscap_typical
+.lib $::180MCU_MODELS/sm141064.ngspice bjt_typical
 * .lib $::180MCU_MODELS/sm141064.ngspice res_statistical
 "}
-C {devices/lab_pin.sym} 130 -490 0 0 {name=l2 sig_type=std_logic lab=P}
-C {devices/lab_pin.sym} 130 -310 0 0 {name=l3 sig_type=std_logic lab=M}
-C {devices/lab_pin.sym} 80 -410 0 0 {name=l4 sig_type=std_logic lab=B}
-C {devices/code_shown.sym} 300 -450 0 0 {name=NGSPICE only_toplevel=true
+C {devices/code_shown.sym} 390 -450 0 0 {name=NGSPICE only_toplevel=true
 value="
-vp p 0 0
-vm m 0 0
-vb b 0 3.3
+vc c 0 dc 3.3
+vb b 0 0
 
 .control
+dc vb 0.4 0.8 0.001
 save all
-dc vp 0 3.3 0.01
-write test_ppolyf_u.raw
+write test_npn_00p54x16p00.raw
 .endc
 "}
 C {devices/title.sym} 160 -30 0 0 {name=l5 author="GlobalFoundries PDK Authors"}
-C {devices/launcher.sym} 65 -645 0 0 {name=h1
+C {devices/launcher.sym} 185 -635 0 0 {name=h1
 descr="Click left mouse button here with control key
 pressed to load/unload waveforms in graph."
 tclcommand="
 xschem raw_read $netlist_dir/[file tail [file rootname [xschem get current_name]]].raw
 "
 }
-C {symbols/ppolyf_u.sym} 130 -410 0 0 {name=R1
-W=1e-6
-L=1e-6
-model=ppolyf_u
+C {symbols/npn_00p54x16p00.sym} 190 -390 0 0 {name=Q1
+model=npn_00p54x16p00
 spiceprefix=X
 m=1}
+C {devices/gnd.sym} 210 -300 0 0 {name=l1 lab=GND}
+C {devices/lab_pin.sym} 130 -390 0 0 {name=l2 sig_type=std_logic lab=B}
+C {devices/lab_pin.sym} 210 -460 0 0 {name=l3 sig_type=std_logic lab=C}

--- a/cells/xschem/tests/test_npn_00p54x16p00.sym
+++ b/cells/xschem/tests/test_npn_00p54x16p00.sym
@@ -1,4 +1,4 @@
-v {xschem version=3.4.5 file_version=1.2
+v {xschem version=3.0.0 file_version=1.2
 
 * Copyright 2022 GlobalFoundries PDK Authors
 *
@@ -15,26 +15,13 @@ v {xschem version=3.4.5 file_version=1.2
 * limitations under the License.
 
 }
-G {}
-K {type=moscap
-format="@spiceprefix@name @pinlist @model c_width=@W c_length=@L m=@m"
-template="name=C1
-W=1e-6
-L=1e-6
-model=cap_nmos_03v3
-spiceprefix=X
-m=1"
+K {type=subcircuit
+format="@name @pinlist @symname"
+template="name=x1"
 }
-V {}
-S {}
-E {}
-L 4 0 10 0 30 {}
-L 4 0 -30 0 -5 {}
-L 4 -15 -5 15 -5 {}
-B 4 -15 5 15 10 {}
-B 5 -2.5 -32.5 2.5 -27.5 {name=G dir=inout propag=1 pinnumber=2}
-B 5 -2.5 27.5 2.5 32.5 {name=B dir=inout propag=0 pinnumber=1}
-T {@m * @W / @L} 20 6.25 0 0 0.2 0.2 {layer=13}
-T {@model} 20 -11.25 0 0 0.2 0.2 {}
-T {@spiceprefix@name} 20 -28.75 0 0 0.2 0.2 {}
-T {PW} -25 12.5 0 0 0.2 0.2 { layer=4}
+T {@symname} -76.5 -6 0 0 0.3 0.3 {}
+T {@name} 135 -22 0 0 0.2 0.2 {}
+L 4 -130 -10 130 -10 {}
+L 4 -130 10 130 10 {}
+L 4 -130 -10 -130 10 {}
+L 4 130 -10 130 10 {}

--- a/cells/xschem/tests/test_npn_05p00x05p00.sch
+++ b/cells/xschem/tests/test_npn_05p00x05p00.sch
@@ -20,33 +20,16 @@ K {}
 V {}
 S {}
 E {}
-B 2 580 -540 1170 -80 {flags=graph
-y1=-0.0067
-y2=0
+B 2 750 -540 1340 -80 {flags=graph
+y1=-9e-05
+y2=-2.7e-11
 ypos1=0
 ypos2=2
 divy=5
 subdivy=1
-unity=m
-x1=0
-x2=3.3
-divx=5
-subdivx=1
-node=i(vp)
-color=4
-
-unitx=1
-dataset=-1}
-B 2 580 -1000 1170 -540 {flags=graph
-y1=-0
-y2=500
-ypos1=0
-ypos2=2
-divy=5
-subdivy=1
-unity=1
-x1=0
-x2=3.3
+unity=u
+x1=0.4
+x2=0.8
 divx=5
 subdivx=1
 
@@ -54,48 +37,68 @@ subdivx=1
 
 unitx=1
 dataset=-1
+
 color=4
-node="\\"resistance; p i(vp) / -1 *\\""}
-N 130 -490 130 -440 {
-lab=P}
-N 80 -410 110 -410 {
+node=i(vc)}
+B 2 750 -1000 1340 -540 {flags=graph
+y1=1.1
+y2=8.2
+ypos1=0
+ypos2=2
+divy=5
+subdivy=1
+unity=1
+x1=0.4
+x2=0.8
+divx=5
+subdivx=1
+
+
+
+unitx=1
+dataset=-1
+
+color=4
+node="\\"Current_gain;i(vc) i(vb) /\\""}
+N 210 -390 210 -300 {
+lab=GND}
+N 130 -390 170 -390 {
 lab=B}
-N 130 -380 130 -310 {
-lab=M}
-C {devices/code_shown.sym} 20 -160 0 0 {name=MODELS only_toplevel=true
+N 210 -460 210 -420 {
+lab=C}
+C {devices/code_shown.sym} 30 -200 0 0 {name=MODELS only_toplevel=true
 format="tcleval( @value )"
 value="
 .include $::180MCU_MODELS/design.ngspice
 .lib $::180MCU_MODELS/sm141064.ngspice typical
 .lib $::180MCU_MODELS/sm141064.ngspice res_typical
+.lib $::180MCU_MODELS/sm141064.ngspice moscap_typical
+.lib $::180MCU_MODELS/sm141064.ngspice bjt_typical
 * .lib $::180MCU_MODELS/sm141064.ngspice res_statistical
 "}
-C {devices/lab_pin.sym} 130 -490 0 0 {name=l2 sig_type=std_logic lab=P}
-C {devices/lab_pin.sym} 130 -310 0 0 {name=l3 sig_type=std_logic lab=M}
-C {devices/lab_pin.sym} 80 -410 0 0 {name=l4 sig_type=std_logic lab=B}
-C {devices/code_shown.sym} 300 -450 0 0 {name=NGSPICE only_toplevel=true
+C {devices/code_shown.sym} 390 -450 0 0 {name=NGSPICE only_toplevel=true
 value="
-vp p 0 0
-vm m 0 0
-vb b 0 3.3
+vc c 0 dc 3.3
+vb b 0 0
 
 .control
+dc vb 0.4 0.8 0.001
 save all
-dc vp 0 3.3 0.01
-write test_ppolyf_u.raw
+write test_npn_05p00x05p00.raw
 .endc
 "}
 C {devices/title.sym} 160 -30 0 0 {name=l5 author="GlobalFoundries PDK Authors"}
-C {devices/launcher.sym} 65 -645 0 0 {name=h1
+C {devices/launcher.sym} 185 -635 0 0 {name=h1
 descr="Click left mouse button here with control key
 pressed to load/unload waveforms in graph."
 tclcommand="
 xschem raw_read $netlist_dir/[file tail [file rootname [xschem get current_name]]].raw
 "
 }
-C {symbols/ppolyf_u.sym} 130 -410 0 0 {name=R1
-W=1e-6
-L=1e-6
-model=ppolyf_u
+C {symbols/npn_05p00x05p00.sym} 190 -390 0 0 {name=Q1
+model=npn_05p00x05p00
 spiceprefix=X
 m=1}
+C {devices/gnd.sym} 210 -300 0 0 {name=l1 lab=GND}
+C {devices/lab_pin.sym} 130 -390 0 0 {name=l2 sig_type=std_logic lab=B}
+C {devices/lab_pin.sym} 210 -460 0 0 {name=l3 sig_type=std_logic lab=C}

--- a/cells/xschem/tests/test_npn_05p00x05p00.sym
+++ b/cells/xschem/tests/test_npn_05p00x05p00.sym
@@ -1,4 +1,4 @@
-v {xschem version=3.4.5 file_version=1.2
+v {xschem version=3.0.0 file_version=1.2
 
 * Copyright 2022 GlobalFoundries PDK Authors
 *
@@ -15,26 +15,13 @@ v {xschem version=3.4.5 file_version=1.2
 * limitations under the License.
 
 }
-G {}
-K {type=moscap
-format="@spiceprefix@name @pinlist @model c_width=@W c_length=@L m=@m"
-template="name=C1
-W=1e-6
-L=1e-6
-model=cap_nmos_03v3
-spiceprefix=X
-m=1"
+K {type=subcircuit
+format="@name @pinlist @symname"
+template="name=x1"
 }
-V {}
-S {}
-E {}
-L 4 0 10 0 30 {}
-L 4 0 -30 0 -5 {}
-L 4 -15 -5 15 -5 {}
-B 4 -15 5 15 10 {}
-B 5 -2.5 -32.5 2.5 -27.5 {name=G dir=inout propag=1 pinnumber=2}
-B 5 -2.5 27.5 2.5 32.5 {name=B dir=inout propag=0 pinnumber=1}
-T {@m * @W / @L} 20 6.25 0 0 0.2 0.2 {layer=13}
-T {@model} 20 -11.25 0 0 0.2 0.2 {}
-T {@spiceprefix@name} 20 -28.75 0 0 0.2 0.2 {}
-T {PW} -25 12.5 0 0 0.2 0.2 { layer=4}
+T {@symname} -76.5 -6 0 0 0.3 0.3 {}
+T {@name} 135 -22 0 0 0.2 0.2 {}
+L 4 -130 -10 130 -10 {}
+L 4 -130 10 130 10 {}
+L 4 -130 -10 -130 10 {}
+L 4 130 -10 130 10 {}

--- a/cells/xschem/tests/test_npolyf_s.sch
+++ b/cells/xschem/tests/test_npolyf_s.sch
@@ -21,7 +21,7 @@ V {}
 S {}
 E {}
 B 2 580 -540 1170 -80 {flags=graph
-y1=-0.0067
+y1=-0.19
 y2=0
 ypos1=0
 ypos2=2
@@ -39,7 +39,7 @@ unitx=1
 dataset=-1}
 B 2 580 -1000 1170 -540 {flags=graph
 y1=-0
-y2=500
+y2=19
 ypos1=0
 ypos2=2
 divy=5
@@ -77,25 +77,25 @@ C {devices/code_shown.sym} 300 -450 0 0 {name=NGSPICE only_toplevel=true
 value="
 vp p 0 0
 vm m 0 0
-vb b 0 3.3
+vb b 0 0
 
 .control
 save all
 dc vp 0 3.3 0.01
-write test_ppolyf_u.raw
+write test_npolyf_s.raw
 .endc
 "}
 C {devices/title.sym} 160 -30 0 0 {name=l5 author="GlobalFoundries PDK Authors"}
-C {devices/launcher.sym} 65 -645 0 0 {name=h1
+C {devices/launcher.sym} 65 -625 0 0 {name=h1
 descr="Click left mouse button here with control key
 pressed to load/unload waveforms in graph."
 tclcommand="
 xschem raw_read $netlist_dir/[file tail [file rootname [xschem get current_name]]].raw
 "
 }
-C {symbols/ppolyf_u.sym} 130 -410 0 0 {name=R1
+C {symbols/npolyf_s.sym} 130 -410 0 0 {name=R1
 W=1e-6
 L=1e-6
-model=ppolyf_u
+model=npolyf_s
 spiceprefix=X
 m=1}

--- a/cells/xschem/tests/test_npolyf_s.sym
+++ b/cells/xschem/tests/test_npolyf_s.sym
@@ -1,4 +1,4 @@
-v {xschem version=3.4.5 file_version=1.2
+v {xschem version=3.0.0 file_version=1.2
 
 * Copyright 2022 GlobalFoundries PDK Authors
 *
@@ -15,26 +15,13 @@ v {xschem version=3.4.5 file_version=1.2
 * limitations under the License.
 
 }
-G {}
-K {type=moscap
-format="@spiceprefix@name @pinlist @model c_width=@W c_length=@L m=@m"
-template="name=C1
-W=1e-6
-L=1e-6
-model=cap_nmos_03v3
-spiceprefix=X
-m=1"
+K {type=subcircuit
+format="@name @pinlist @symname"
+template="name=x1"
 }
-V {}
-S {}
-E {}
-L 4 0 10 0 30 {}
-L 4 0 -30 0 -5 {}
-L 4 -15 -5 15 -5 {}
-B 4 -15 5 15 10 {}
-B 5 -2.5 -32.5 2.5 -27.5 {name=G dir=inout propag=1 pinnumber=2}
-B 5 -2.5 27.5 2.5 32.5 {name=B dir=inout propag=0 pinnumber=1}
-T {@m * @W / @L} 20 6.25 0 0 0.2 0.2 {layer=13}
-T {@model} 20 -11.25 0 0 0.2 0.2 {}
-T {@spiceprefix@name} 20 -28.75 0 0 0.2 0.2 {}
-T {PW} -25 12.5 0 0 0.2 0.2 { layer=4}
+T {@symname} -76.5 -6 0 0 0.3 0.3 {}
+T {@name} 135 -22 0 0 0.2 0.2 {}
+L 4 -130 -10 130 -10 {}
+L 4 -130 10 130 10 {}
+L 4 -130 -10 -130 10 {}
+L 4 130 -10 130 10 {}

--- a/cells/xschem/tests/test_pfet_06v0_dss.sch
+++ b/cells/xschem/tests/test_pfet_06v0_dss.sch
@@ -21,81 +21,71 @@ V {}
 S {}
 E {}
 B 2 580 -540 1170 -80 {flags=graph
-y1=-0.0067
-y2=0
+y1=0
+y2=0.00011
 ypos1=0
 ypos2=2
 divy=5
 subdivy=1
-unity=m
+unity=u
 x1=0
-x2=3.3
+x2=6
 divx=5
 subdivx=1
-node=i(vp)
+node=i(vd)
 color=4
 
 unitx=1
 dataset=-1}
-B 2 580 -1000 1170 -540 {flags=graph
-y1=-0
-y2=500
-ypos1=0
-ypos2=2
-divy=5
-subdivy=1
-unity=1
-x1=0
-x2=3.3
-divx=5
-subdivx=1
-
-
-
-unitx=1
-dataset=-1
-color=4
-node="\\"resistance; p i(vp) / -1 *\\""}
+N 50 -410 90 -410 {
+lab=G}
 N 130 -490 130 -440 {
-lab=P}
-N 80 -410 110 -410 {
+lab=S}
+N 130 -410 230 -410 {
 lab=B}
 N 130 -380 130 -310 {
-lab=M}
-C {devices/code_shown.sym} 20 -160 0 0 {name=MODELS only_toplevel=true
-format="tcleval( @value )"
-value="
-.include $::180MCU_MODELS/design.ngspice
-.lib $::180MCU_MODELS/sm141064.ngspice typical
-.lib $::180MCU_MODELS/sm141064.ngspice res_typical
-* .lib $::180MCU_MODELS/sm141064.ngspice res_statistical
-"}
-C {devices/lab_pin.sym} 130 -490 0 0 {name=l2 sig_type=std_logic lab=P}
-C {devices/lab_pin.sym} 130 -310 0 0 {name=l3 sig_type=std_logic lab=M}
-C {devices/lab_pin.sym} 80 -410 0 0 {name=l4 sig_type=std_logic lab=B}
+lab=D}
+C {devices/lab_pin.sym} 50 -410 0 0 {name=l1 sig_type=std_logic lab=G}
+C {devices/lab_pin.sym} 130 -490 0 0 {name=l2 sig_type=std_logic lab=S}
+C {devices/lab_pin.sym} 130 -310 0 0 {name=l3 sig_type=std_logic lab=D}
+C {devices/lab_pin.sym} 230 -410 0 1 {name=l4 sig_type=std_logic lab=B}
 C {devices/code_shown.sym} 300 -450 0 0 {name=NGSPICE only_toplevel=true
 value="
-vp p 0 0
-vm m 0 0
-vb b 0 3.3
-
+vg g 0 0
+vd d 0 0
+vs s 0 6
+vb b 0 6
 .control
 save all
-dc vp 0 3.3 0.01
-write test_ppolyf_u.raw
+dc vd 0 6 0.01 vg 0 6 1
+write test_pfet_06v0_dss.raw
 .endc
 "}
 C {devices/title.sym} 160 -30 0 0 {name=l5 author="GlobalFoundries PDK Authors"}
-C {devices/launcher.sym} 65 -645 0 0 {name=h1
+C {devices/launcher.sym} 185 -635 0 0 {name=h1
 descr="Click left mouse button here with control key
 pressed to load/unload waveforms in graph."
 tclcommand="
 xschem raw_read $netlist_dir/[file tail [file rootname [xschem get current_name]]].raw
 "
 }
-C {symbols/ppolyf_u.sym} 130 -410 0 0 {name=R1
-W=1e-6
-L=1e-6
-model=ppolyf_u
+C {symbols/pfet_06v0_dss.sym} 110 -410 0 0 {name=M1
+L=0.50u
+W=0.30u
+nf=1
+mult=1
+ad="'int((nf+1)/2) * W/nf * 0.18u'"
+pd="'2*int((nf+1)/2) * (W/nf + 0.18u)'"
+as="'int((nf+2)/2) * W/nf * 0.18u'"
+ps="'2*int((nf+2)/2) * (W/nf + 0.18u)'"
+nrd="'0.18u / W'" nrs="'0.18u / W'"
+sa=0 sb=0 sd=0
+model=pfet_06v0_dss
 spiceprefix=X
-m=1}
+}
+C {devices/code_shown.sym} 60 -170 0 0 {name=MODELS only_toplevel=true
+format="tcleval( @value )"
+value="
+.include $::180MCU_MODELS/design.ngspice
+.lib $::180MCU_MODELS/sm141064.ngspice typical
+"}

--- a/cells/xschem/tests/test_pfet_06v0_dss.sym
+++ b/cells/xschem/tests/test_pfet_06v0_dss.sym
@@ -1,4 +1,4 @@
-v {xschem version=3.4.5 file_version=1.2
+v {xschem version=3.0.0 file_version=1.2
 
 * Copyright 2022 GlobalFoundries PDK Authors
 *
@@ -15,26 +15,13 @@ v {xschem version=3.4.5 file_version=1.2
 * limitations under the License.
 
 }
-G {}
-K {type=moscap
-format="@spiceprefix@name @pinlist @model c_width=@W c_length=@L m=@m"
-template="name=C1
-W=1e-6
-L=1e-6
-model=cap_nmos_03v3
-spiceprefix=X
-m=1"
+K {type=subcircuit
+format="@name @pinlist @symname"
+template="name=x1"
 }
-V {}
-S {}
-E {}
-L 4 0 10 0 30 {}
-L 4 0 -30 0 -5 {}
-L 4 -15 -5 15 -5 {}
-B 4 -15 5 15 10 {}
-B 5 -2.5 -32.5 2.5 -27.5 {name=G dir=inout propag=1 pinnumber=2}
-B 5 -2.5 27.5 2.5 32.5 {name=B dir=inout propag=0 pinnumber=1}
-T {@m * @W / @L} 20 6.25 0 0 0.2 0.2 {layer=13}
-T {@model} 20 -11.25 0 0 0.2 0.2 {}
-T {@spiceprefix@name} 20 -28.75 0 0 0.2 0.2 {}
-T {PW} -25 12.5 0 0 0.2 0.2 { layer=4}
+T {@symname} -76.5 -6 0 0 0.3 0.3 {}
+T {@name} 135 -22 0 0 0.2 0.2 {}
+L 4 -130 -10 130 -10 {}
+L 4 -130 10 130 10 {}
+L 4 -130 -10 -130 10 {}
+L 4 130 -10 130 10 {}

--- a/cells/xschem/tests/test_pfet_10v0_asym.sch
+++ b/cells/xschem/tests/test_pfet_10v0_asym.sch
@@ -21,81 +21,72 @@ V {}
 S {}
 E {}
 B 2 580 -540 1170 -80 {flags=graph
-y1=-0.0067
-y2=0
+y1=2e-15
+y2=0.0064
 ypos1=0
 ypos2=2
 divy=5
 subdivy=1
 unity=m
 x1=0
-x2=3.3
+x2=6
 divx=5
 subdivx=1
-node=i(vp)
+node=i(vd)
 color=4
 
 unitx=1
 dataset=-1}
-B 2 580 -1000 1170 -540 {flags=graph
-y1=-0
-y2=500
-ypos1=0
-ypos2=2
-divy=5
-subdivy=1
-unity=1
-x1=0
-x2=3.3
-divx=5
-subdivx=1
-
-
-
-unitx=1
-dataset=-1
-color=4
-node="\\"resistance; p i(vp) / -1 *\\""}
+N 50 -410 90 -410 {
+lab=G}
 N 130 -490 130 -440 {
-lab=P}
-N 80 -410 110 -410 {
+lab=S}
+N 130 -410 230 -410 {
 lab=B}
 N 130 -380 130 -310 {
-lab=M}
-C {devices/code_shown.sym} 20 -160 0 0 {name=MODELS only_toplevel=true
-format="tcleval( @value )"
+lab=D}
+C {devices/lab_pin.sym} 50 -410 0 0 {name=l1 sig_type=std_logic lab=G}
+C {devices/lab_pin.sym} 130 -490 0 0 {name=l2 sig_type=std_logic lab=S}
+C {devices/lab_pin.sym} 130 -310 0 0 {name=l3 sig_type=std_logic lab=D}
+C {devices/lab_pin.sym} 230 -410 0 1 {name=l4 sig_type=std_logic lab=B}
+C {devices/code_shown.sym} 270 -460 0 0 {name=NGSPICE only_toplevel=true
 value="
-.include $::180MCU_MODELS/design.ngspice
-.lib $::180MCU_MODELS/sm141064.ngspice typical
-.lib $::180MCU_MODELS/sm141064.ngspice res_typical
-* .lib $::180MCU_MODELS/sm141064.ngspice res_statistical
-"}
-C {devices/lab_pin.sym} 130 -490 0 0 {name=l2 sig_type=std_logic lab=P}
-C {devices/lab_pin.sym} 130 -310 0 0 {name=l3 sig_type=std_logic lab=M}
-C {devices/lab_pin.sym} 80 -410 0 0 {name=l4 sig_type=std_logic lab=B}
-C {devices/code_shown.sym} 300 -450 0 0 {name=NGSPICE only_toplevel=true
-value="
-vp p 0 0
-vm m 0 0
-vb b 0 3.3
-
+vg g 0 0
+vd d 0 0
+vs s 0 6
+vb b 0 6
 .control
 save all
-dc vp 0 3.3 0.01
-write test_ppolyf_u.raw
+dc vd 0 6 0.01 vg 0 6 1
+write test_pfet_10v0_asym.raw
 .endc
 "}
 C {devices/title.sym} 160 -30 0 0 {name=l5 author="GlobalFoundries PDK Authors"}
-C {devices/launcher.sym} 65 -645 0 0 {name=h1
+C {devices/launcher.sym} 185 -635 0 0 {name=h1
 descr="Click left mouse button here with control key
 pressed to load/unload waveforms in graph."
 tclcommand="
 xschem raw_read $netlist_dir/[file tail [file rootname [xschem get current_name]]].raw
 "
 }
-C {symbols/ppolyf_u.sym} 130 -410 0 0 {name=R1
-W=1e-6
-L=1e-6
-model=ppolyf_u
+C {devices/code_shown.sym} 60 -170 0 0 {name=MODELS only_toplevel=true
+format="tcleval( @value )"
+value="
+.include $::180MCU_MODELS/design.ngspice
+.lib $::180MCU_MODELS/sm141064.ngspice typical
+.lib $::180MCU_MODELS/smbb000149.ngspice typical
+"}
+C {symbols/pfet_10v0_asym.sym} 110 -410 0 0 {name=M1
+L=0.6u
+W=25u
+nf=1
+m=1
+ad="'W * 1.78u'"
+pd="'2 * (W + 1.78u)'"
+as="'W * 0.48u'"
+ps="'2 * (W + 0.48u)'"
+nrd=0 nrs=0
+sa=0 sb=0 sd=0
+model=pfet_10v0_asym
 spiceprefix=X
-m=1}
+}

--- a/cells/xschem/tests/test_pfet_10v0_asym.sym
+++ b/cells/xschem/tests/test_pfet_10v0_asym.sym
@@ -1,4 +1,4 @@
-v {xschem version=3.4.5 file_version=1.2
+v {xschem version=3.0.0 file_version=1.2
 
 * Copyright 2022 GlobalFoundries PDK Authors
 *
@@ -15,26 +15,13 @@ v {xschem version=3.4.5 file_version=1.2
 * limitations under the License.
 
 }
-G {}
-K {type=moscap
-format="@spiceprefix@name @pinlist @model c_width=@W c_length=@L m=@m"
-template="name=C1
-W=1e-6
-L=1e-6
-model=cap_nmos_03v3
-spiceprefix=X
-m=1"
+K {type=subcircuit
+format="@name @pinlist @symname"
+template="name=x1"
 }
-V {}
-S {}
-E {}
-L 4 0 10 0 30 {}
-L 4 0 -30 0 -5 {}
-L 4 -15 -5 15 -5 {}
-B 4 -15 5 15 10 {}
-B 5 -2.5 -32.5 2.5 -27.5 {name=G dir=inout propag=1 pinnumber=2}
-B 5 -2.5 27.5 2.5 32.5 {name=B dir=inout propag=0 pinnumber=1}
-T {@m * @W / @L} 20 6.25 0 0 0.2 0.2 {layer=13}
-T {@model} 20 -11.25 0 0 0.2 0.2 {}
-T {@spiceprefix@name} 20 -28.75 0 0 0.2 0.2 {}
-T {PW} -25 12.5 0 0 0.2 0.2 { layer=4}
+T {@symname} -76.5 -6 0 0 0.3 0.3 {}
+T {@name} 135 -22 0 0 0.2 0.2 {}
+L 4 -130 -10 130 -10 {}
+L 4 -130 10 130 10 {}
+L 4 -130 -10 -130 10 {}
+L 4 130 -10 130 10 {}

--- a/cells/xschem/tests/test_pnp_05p00x00p42.sch
+++ b/cells/xschem/tests/test_pnp_05p00x00p42.sch
@@ -20,33 +20,16 @@ K {}
 V {}
 S {}
 E {}
-B 2 580 -540 1170 -80 {flags=graph
-y1=-0.0067
-y2=0
+B 2 750 -540 1340 -80 {flags=graph
+y1=-2.4e-05
+y2=-7.1e-12
 ypos1=0
 ypos2=2
 divy=5
 subdivy=1
-unity=m
-x1=0
-x2=3.3
-divx=5
-subdivx=1
-node=i(vp)
-color=4
-
-unitx=1
-dataset=-1}
-B 2 580 -1000 1170 -540 {flags=graph
-y1=-0
-y2=500
-ypos1=0
-ypos2=2
-divy=5
-subdivy=1
-unity=1
-x1=0
-x2=3.3
+unity=u
+x1=0.4
+x2=0.8
 divx=5
 subdivx=1
 
@@ -54,48 +37,69 @@ subdivx=1
 
 unitx=1
 dataset=-1
+
 color=4
-node="\\"resistance; p i(vp) / -1 *\\""}
-N 130 -490 130 -440 {
-lab=P}
-N 80 -410 110 -410 {
-lab=B}
-N 130 -380 130 -310 {
-lab=M}
-C {devices/code_shown.sym} 20 -160 0 0 {name=MODELS only_toplevel=true
+node=i(ve)}
+B 2 750 -1000 1340 -540 {flags=graph
+y1=1.7
+y2=2.7
+ypos1=0
+ypos2=2
+divy=5
+subdivy=1
+unity=1
+x1=0.4
+x2=0.8
+divx=5
+subdivx=1
+
+
+
+unitx=1
+dataset=-1
+
+color=4
+node="\\"Current_gain;i(ve) i(vb) /\\""}
+N 80 -390 170 -390 {
+lab=#net1}
+N 210 -460 210 -420 {
+lab=E}
+N 80 -330 210 -330 {
+lab=GND}
+N 210 -360 210 -300 {
+lab=GND}
+C {devices/code_shown.sym} 30 -200 0 0 {name=MODELS only_toplevel=true
 format="tcleval( @value )"
 value="
 .include $::180MCU_MODELS/design.ngspice
 .lib $::180MCU_MODELS/sm141064.ngspice typical
 .lib $::180MCU_MODELS/sm141064.ngspice res_typical
+.lib $::180MCU_MODELS/sm141064.ngspice moscap_typical
+.lib $::180MCU_MODELS/sm141064.ngspice bjt_typical
 * .lib $::180MCU_MODELS/sm141064.ngspice res_statistical
 "}
-C {devices/lab_pin.sym} 130 -490 0 0 {name=l2 sig_type=std_logic lab=P}
-C {devices/lab_pin.sym} 130 -310 0 0 {name=l3 sig_type=std_logic lab=M}
-C {devices/lab_pin.sym} 80 -410 0 0 {name=l4 sig_type=std_logic lab=B}
-C {devices/code_shown.sym} 300 -450 0 0 {name=NGSPICE only_toplevel=true
+C {devices/code_shown.sym} 390 -450 0 0 {name=NGSPICE only_toplevel=true
 value="
-vp p 0 0
-vm m 0 0
-vb b 0 3.3
+ve e 0 0
 
 .control
 save all
-dc vp 0 3.3 0.01
-write test_ppolyf_u.raw
+dc ve 0.4 0.8 0.001
+write test_pnp_05p00x00p42.raw
 .endc
 "}
 C {devices/title.sym} 160 -30 0 0 {name=l5 author="GlobalFoundries PDK Authors"}
-C {devices/launcher.sym} 65 -645 0 0 {name=h1
+C {devices/launcher.sym} 185 -635 0 0 {name=h1
 descr="Click left mouse button here with control key
 pressed to load/unload waveforms in graph."
 tclcommand="
 xschem raw_read $netlist_dir/[file tail [file rootname [xschem get current_name]]].raw
 "
 }
-C {symbols/ppolyf_u.sym} 130 -410 0 0 {name=R1
-W=1e-6
-L=1e-6
-model=ppolyf_u
+C {symbols/pnp_05p00x00p42.sym} 190 -390 0 0 {name=Q1
+model=pnp_05p00x00p42
 spiceprefix=X
 m=1}
+C {devices/gnd.sym} 210 -300 0 0 {name=l1 lab=GND}
+C {devices/lab_pin.sym} 210 -460 0 0 {name=l3 sig_type=std_logic lab=E}
+C {devices/ammeter.sym} 80 -360 2 0 {name=Vb}

--- a/cells/xschem/tests/test_pnp_05p00x00p42.sym
+++ b/cells/xschem/tests/test_pnp_05p00x00p42.sym
@@ -1,4 +1,4 @@
-v {xschem version=3.4.5 file_version=1.2
+v {xschem version=3.0.0 file_version=1.2
 
 * Copyright 2022 GlobalFoundries PDK Authors
 *
@@ -15,26 +15,13 @@ v {xschem version=3.4.5 file_version=1.2
 * limitations under the License.
 
 }
-G {}
-K {type=moscap
-format="@spiceprefix@name @pinlist @model c_width=@W c_length=@L m=@m"
-template="name=C1
-W=1e-6
-L=1e-6
-model=cap_nmos_03v3
-spiceprefix=X
-m=1"
+K {type=subcircuit
+format="@name @pinlist @symname"
+template="name=x1"
 }
-V {}
-S {}
-E {}
-L 4 0 10 0 30 {}
-L 4 0 -30 0 -5 {}
-L 4 -15 -5 15 -5 {}
-B 4 -15 5 15 10 {}
-B 5 -2.5 -32.5 2.5 -27.5 {name=G dir=inout propag=1 pinnumber=2}
-B 5 -2.5 27.5 2.5 32.5 {name=B dir=inout propag=0 pinnumber=1}
-T {@m * @W / @L} 20 6.25 0 0 0.2 0.2 {layer=13}
-T {@model} 20 -11.25 0 0 0.2 0.2 {}
-T {@spiceprefix@name} 20 -28.75 0 0 0.2 0.2 {}
-T {PW} -25 12.5 0 0 0.2 0.2 { layer=4}
+T {@symname} -76.5 -6 0 0 0.3 0.3 {}
+T {@name} 135 -22 0 0 0.2 0.2 {}
+L 4 -130 -10 130 -10 {}
+L 4 -130 10 130 10 {}
+L 4 -130 -10 -130 10 {}
+L 4 130 -10 130 10 {}

--- a/cells/xschem/tests/test_pnp_05p00x05p00.sch
+++ b/cells/xschem/tests/test_pnp_05p00x05p00.sch
@@ -20,33 +20,16 @@ K {}
 V {}
 S {}
 E {}
-B 2 580 -540 1170 -80 {flags=graph
-y1=-0.0067
-y2=0
+B 2 750 -540 1340 -80 {flags=graph
+y1=-0.00017
+y2=-4.3e-11
 ypos1=0
 ypos2=2
 divy=5
 subdivy=1
-unity=m
-x1=0
-x2=3.3
-divx=5
-subdivx=1
-node=i(vp)
-color=4
-
-unitx=1
-dataset=-1}
-B 2 580 -1000 1170 -540 {flags=graph
-y1=-0
-y2=500
-ypos1=0
-ypos2=2
-divy=5
-subdivy=1
-unity=1
-x1=0
-x2=3.3
+unity=u
+x1=0.4
+x2=0.8
 divx=5
 subdivx=1
 
@@ -54,48 +37,69 @@ subdivx=1
 
 unitx=1
 dataset=-1
+
 color=4
-node="\\"resistance; p i(vp) / -1 *\\""}
-N 130 -490 130 -440 {
-lab=P}
-N 80 -410 110 -410 {
-lab=B}
-N 130 -380 130 -310 {
-lab=M}
-C {devices/code_shown.sym} 20 -160 0 0 {name=MODELS only_toplevel=true
+node=i(ve)}
+B 2 750 -1000 1340 -540 {flags=graph
+y1=2.2
+y2=2.7
+ypos1=0
+ypos2=2
+divy=5
+subdivy=1
+unity=1
+x1=0.4
+x2=0.8
+divx=5
+subdivx=1
+
+
+
+unitx=1
+dataset=-1
+
+color=4
+node="\\"Current_gain;i(ve) i(vb) /\\""}
+N 80 -390 170 -390 {
+lab=#net1}
+N 210 -460 210 -420 {
+lab=E}
+N 80 -330 210 -330 {
+lab=GND}
+N 210 -360 210 -300 {
+lab=GND}
+C {devices/code_shown.sym} 30 -200 0 0 {name=MODELS only_toplevel=true
 format="tcleval( @value )"
 value="
 .include $::180MCU_MODELS/design.ngspice
 .lib $::180MCU_MODELS/sm141064.ngspice typical
 .lib $::180MCU_MODELS/sm141064.ngspice res_typical
+.lib $::180MCU_MODELS/sm141064.ngspice moscap_typical
+.lib $::180MCU_MODELS/sm141064.ngspice bjt_typical
 * .lib $::180MCU_MODELS/sm141064.ngspice res_statistical
 "}
-C {devices/lab_pin.sym} 130 -490 0 0 {name=l2 sig_type=std_logic lab=P}
-C {devices/lab_pin.sym} 130 -310 0 0 {name=l3 sig_type=std_logic lab=M}
-C {devices/lab_pin.sym} 80 -410 0 0 {name=l4 sig_type=std_logic lab=B}
-C {devices/code_shown.sym} 300 -450 0 0 {name=NGSPICE only_toplevel=true
+C {devices/code_shown.sym} 390 -450 0 0 {name=NGSPICE only_toplevel=true
 value="
-vp p 0 0
-vm m 0 0
-vb b 0 3.3
+ve e 0 0
 
 .control
 save all
-dc vp 0 3.3 0.01
-write test_ppolyf_u.raw
+dc ve 0.4 0.8 0.001
+write test_pnp_05p00x05p00.raw
 .endc
 "}
 C {devices/title.sym} 160 -30 0 0 {name=l5 author="GlobalFoundries PDK Authors"}
-C {devices/launcher.sym} 65 -645 0 0 {name=h1
+C {devices/launcher.sym} 185 -635 0 0 {name=h1
 descr="Click left mouse button here with control key
 pressed to load/unload waveforms in graph."
 tclcommand="
 xschem raw_read $netlist_dir/[file tail [file rootname [xschem get current_name]]].raw
 "
 }
-C {symbols/ppolyf_u.sym} 130 -410 0 0 {name=R1
-W=1e-6
-L=1e-6
-model=ppolyf_u
+C {symbols/pnp_05p00x05p00.sym} 190 -390 0 0 {name=Q1
+model=pnp_05p00x05p00
 spiceprefix=X
 m=1}
+C {devices/gnd.sym} 210 -300 0 0 {name=l1 lab=GND}
+C {devices/lab_pin.sym} 210 -460 0 0 {name=l3 sig_type=std_logic lab=E}
+C {devices/ammeter.sym} 80 -360 2 0 {name=Vb}

--- a/cells/xschem/tests/test_pnp_05p00x05p00.sym
+++ b/cells/xschem/tests/test_pnp_05p00x05p00.sym
@@ -1,4 +1,4 @@
-v {xschem version=3.4.5 file_version=1.2
+v {xschem version=3.0.0 file_version=1.2
 
 * Copyright 2022 GlobalFoundries PDK Authors
 *
@@ -15,26 +15,13 @@ v {xschem version=3.4.5 file_version=1.2
 * limitations under the License.
 
 }
-G {}
-K {type=moscap
-format="@spiceprefix@name @pinlist @model c_width=@W c_length=@L m=@m"
-template="name=C1
-W=1e-6
-L=1e-6
-model=cap_nmos_03v3
-spiceprefix=X
-m=1"
+K {type=subcircuit
+format="@name @pinlist @symname"
+template="name=x1"
 }
-V {}
-S {}
-E {}
-L 4 0 10 0 30 {}
-L 4 0 -30 0 -5 {}
-L 4 -15 -5 15 -5 {}
-B 4 -15 5 15 10 {}
-B 5 -2.5 -32.5 2.5 -27.5 {name=G dir=inout propag=1 pinnumber=2}
-B 5 -2.5 27.5 2.5 32.5 {name=B dir=inout propag=0 pinnumber=1}
-T {@m * @W / @L} 20 6.25 0 0 0.2 0.2 {layer=13}
-T {@model} 20 -11.25 0 0 0.2 0.2 {}
-T {@spiceprefix@name} 20 -28.75 0 0 0.2 0.2 {}
-T {PW} -25 12.5 0 0 0.2 0.2 { layer=4}
+T {@symname} -76.5 -6 0 0 0.3 0.3 {}
+T {@name} 135 -22 0 0 0.2 0.2 {}
+L 4 -130 -10 130 -10 {}
+L 4 -130 10 130 10 {}
+L 4 -130 -10 -130 10 {}
+L 4 130 -10 130 10 {}

--- a/cells/xschem/tests/test_pnp_10p00x00p42.sch
+++ b/cells/xschem/tests/test_pnp_10p00x00p42.sch
@@ -20,33 +20,16 @@ K {}
 V {}
 S {}
 E {}
-B 2 580 -540 1170 -80 {flags=graph
-y1=-0.0067
-y2=0
+B 2 750 -540 1340 -80 {flags=graph
+y1=-4.8e-05
+y2=-1.4e-11
 ypos1=0
 ypos2=2
 divy=5
 subdivy=1
-unity=m
-x1=0
-x2=3.3
-divx=5
-subdivx=1
-node=i(vp)
-color=4
-
-unitx=1
-dataset=-1}
-B 2 580 -1000 1170 -540 {flags=graph
-y1=-0
-y2=500
-ypos1=0
-ypos2=2
-divy=5
-subdivy=1
-unity=1
-x1=0
-x2=3.3
+unity=u
+x1=0.4
+x2=0.8
 divx=5
 subdivx=1
 
@@ -54,48 +37,69 @@ subdivx=1
 
 unitx=1
 dataset=-1
+
 color=4
-node="\\"resistance; p i(vp) / -1 *\\""}
-N 130 -490 130 -440 {
-lab=P}
-N 80 -410 110 -410 {
-lab=B}
-N 130 -380 130 -310 {
-lab=M}
-C {devices/code_shown.sym} 20 -160 0 0 {name=MODELS only_toplevel=true
+node=i(ve)}
+B 2 750 -1000 1340 -540 {flags=graph
+y1=1.7
+y2=2.7
+ypos1=0
+ypos2=2
+divy=5
+subdivy=1
+unity=1
+x1=0.4
+x2=0.8
+divx=5
+subdivx=1
+
+
+
+unitx=1
+dataset=-1
+
+color=4
+node="\\"Current_gain;i(ve) i(vb) /\\""}
+N 80 -390 170 -390 {
+lab=#net1}
+N 210 -460 210 -420 {
+lab=E}
+N 80 -330 210 -330 {
+lab=GND}
+N 210 -360 210 -300 {
+lab=GND}
+C {devices/code_shown.sym} 30 -200 0 0 {name=MODELS only_toplevel=true
 format="tcleval( @value )"
 value="
 .include $::180MCU_MODELS/design.ngspice
 .lib $::180MCU_MODELS/sm141064.ngspice typical
 .lib $::180MCU_MODELS/sm141064.ngspice res_typical
+.lib $::180MCU_MODELS/sm141064.ngspice moscap_typical
+.lib $::180MCU_MODELS/sm141064.ngspice bjt_typical
 * .lib $::180MCU_MODELS/sm141064.ngspice res_statistical
 "}
-C {devices/lab_pin.sym} 130 -490 0 0 {name=l2 sig_type=std_logic lab=P}
-C {devices/lab_pin.sym} 130 -310 0 0 {name=l3 sig_type=std_logic lab=M}
-C {devices/lab_pin.sym} 80 -410 0 0 {name=l4 sig_type=std_logic lab=B}
-C {devices/code_shown.sym} 300 -450 0 0 {name=NGSPICE only_toplevel=true
+C {devices/code_shown.sym} 390 -450 0 0 {name=NGSPICE only_toplevel=true
 value="
-vp p 0 0
-vm m 0 0
-vb b 0 3.3
+ve e 0 0
 
 .control
 save all
-dc vp 0 3.3 0.01
-write test_ppolyf_u.raw
+dc ve 0.4 0.8 0.001
+write test_pnp_10p00x00p42.raw
 .endc
 "}
 C {devices/title.sym} 160 -30 0 0 {name=l5 author="GlobalFoundries PDK Authors"}
-C {devices/launcher.sym} 65 -645 0 0 {name=h1
+C {devices/launcher.sym} 185 -635 0 0 {name=h1
 descr="Click left mouse button here with control key
 pressed to load/unload waveforms in graph."
 tclcommand="
 xschem raw_read $netlist_dir/[file tail [file rootname [xschem get current_name]]].raw
 "
 }
-C {symbols/ppolyf_u.sym} 130 -410 0 0 {name=R1
-W=1e-6
-L=1e-6
-model=ppolyf_u
+C {symbols/pnp_10p00x00p42.sym} 190 -390 0 0 {name=Q1
+model=pnp_10p00x00p42
 spiceprefix=X
 m=1}
+C {devices/gnd.sym} 210 -300 0 0 {name=l1 lab=GND}
+C {devices/lab_pin.sym} 210 -460 0 0 {name=l3 sig_type=std_logic lab=E}
+C {devices/ammeter.sym} 80 -360 2 0 {name=Vb}

--- a/cells/xschem/tests/test_pnp_10p00x00p42.sym
+++ b/cells/xschem/tests/test_pnp_10p00x00p42.sym
@@ -1,4 +1,4 @@
-v {xschem version=3.4.5 file_version=1.2
+v {xschem version=3.0.0 file_version=1.2
 
 * Copyright 2022 GlobalFoundries PDK Authors
 *
@@ -15,26 +15,13 @@ v {xschem version=3.4.5 file_version=1.2
 * limitations under the License.
 
 }
-G {}
-K {type=moscap
-format="@spiceprefix@name @pinlist @model c_width=@W c_length=@L m=@m"
-template="name=C1
-W=1e-6
-L=1e-6
-model=cap_nmos_03v3
-spiceprefix=X
-m=1"
+K {type=subcircuit
+format="@name @pinlist @symname"
+template="name=x1"
 }
-V {}
-S {}
-E {}
-L 4 0 10 0 30 {}
-L 4 0 -30 0 -5 {}
-L 4 -15 -5 15 -5 {}
-B 4 -15 5 15 10 {}
-B 5 -2.5 -32.5 2.5 -27.5 {name=G dir=inout propag=1 pinnumber=2}
-B 5 -2.5 27.5 2.5 32.5 {name=B dir=inout propag=0 pinnumber=1}
-T {@m * @W / @L} 20 6.25 0 0 0.2 0.2 {layer=13}
-T {@model} 20 -11.25 0 0 0.2 0.2 {}
-T {@spiceprefix@name} 20 -28.75 0 0 0.2 0.2 {}
-T {PW} -25 12.5 0 0 0.2 0.2 { layer=4}
+T {@symname} -76.5 -6 0 0 0.3 0.3 {}
+T {@name} 135 -22 0 0 0.2 0.2 {}
+L 4 -130 -10 130 -10 {}
+L 4 -130 10 130 10 {}
+L 4 -130 -10 -130 10 {}
+L 4 130 -10 130 10 {}

--- a/cells/xschem/tests/test_pnp_10p00x10p00.sch
+++ b/cells/xschem/tests/test_pnp_10p00x10p00.sch
@@ -1,4 +1,4 @@
-v {xschem version=3.0.0 file_version=1.2
+v {xschem version=3.4.5 file_version=1.2
 
 * Copyright 2022 GlobalFoundries PDK Authors
 *
@@ -21,8 +21,8 @@ V {}
 S {}
 E {}
 B 2 750 -540 1340 -80 {flags=graph
-y1=-0.000416
-y2=0.000104
+y1=-0.00052
+y2=-1.4e-10
 ypos1=0
 ypos2=2
 divy=5

--- a/cells/xschem/tests/test_ppolyf_s.sch
+++ b/cells/xschem/tests/test_ppolyf_s.sch
@@ -21,7 +21,7 @@ V {}
 S {}
 E {}
 B 2 580 -540 1170 -80 {flags=graph
-y1=-0.0067
+y1=-0.19
 y2=0
 ypos1=0
 ypos2=2
@@ -39,7 +39,7 @@ unitx=1
 dataset=-1}
 B 2 580 -1000 1170 -540 {flags=graph
 y1=-0
-y2=500
+y2=18
 ypos1=0
 ypos2=2
 divy=5
@@ -82,7 +82,7 @@ vb b 0 3.3
 .control
 save all
 dc vp 0 3.3 0.01
-write test_ppolyf_u.raw
+write test_ppolyf_s.raw
 .endc
 "}
 C {devices/title.sym} 160 -30 0 0 {name=l5 author="GlobalFoundries PDK Authors"}
@@ -93,9 +93,9 @@ tclcommand="
 xschem raw_read $netlist_dir/[file tail [file rootname [xschem get current_name]]].raw
 "
 }
-C {symbols/ppolyf_u.sym} 130 -410 0 0 {name=R1
+C {symbols/ppolyf_s.sym} 130 -410 0 0 {name=R1
 W=1e-6
 L=1e-6
-model=ppolyf_u
+model=ppolyf_s
 spiceprefix=X
 m=1}

--- a/cells/xschem/tests/test_ppolyf_s.sym
+++ b/cells/xschem/tests/test_ppolyf_s.sym
@@ -1,4 +1,4 @@
-v {xschem version=3.4.5 file_version=1.2
+v {xschem version=3.0.0 file_version=1.2
 
 * Copyright 2022 GlobalFoundries PDK Authors
 *
@@ -15,26 +15,13 @@ v {xschem version=3.4.5 file_version=1.2
 * limitations under the License.
 
 }
-G {}
-K {type=moscap
-format="@spiceprefix@name @pinlist @model c_width=@W c_length=@L m=@m"
-template="name=C1
-W=1e-6
-L=1e-6
-model=cap_nmos_03v3
-spiceprefix=X
-m=1"
+K {type=subcircuit
+format="@name @pinlist @symname"
+template="name=x1"
 }
-V {}
-S {}
-E {}
-L 4 0 10 0 30 {}
-L 4 0 -30 0 -5 {}
-L 4 -15 -5 15 -5 {}
-B 4 -15 5 15 10 {}
-B 5 -2.5 -32.5 2.5 -27.5 {name=G dir=inout propag=1 pinnumber=2}
-B 5 -2.5 27.5 2.5 32.5 {name=B dir=inout propag=0 pinnumber=1}
-T {@m * @W / @L} 20 6.25 0 0 0.2 0.2 {layer=13}
-T {@model} 20 -11.25 0 0 0.2 0.2 {}
-T {@spiceprefix@name} 20 -28.75 0 0 0.2 0.2 {}
-T {PW} -25 12.5 0 0 0.2 0.2 { layer=4}
+T {@symname} -76.5 -6 0 0 0.3 0.3 {}
+T {@name} 135 -22 0 0 0.2 0.2 {}
+L 4 -130 -10 130 -10 {}
+L 4 -130 10 130 10 {}
+L 4 -130 -10 -130 10 {}
+L 4 130 -10 130 10 {}

--- a/cells/xschem/tests/test_ppolyf_u_1k.sch
+++ b/cells/xschem/tests/test_ppolyf_u_1k.sch
@@ -21,7 +21,7 @@ V {}
 S {}
 E {}
 B 2 580 -540 1170 -80 {flags=graph
-y1=-0.0067
+y1=-0.0028
 y2=0
 ypos1=0
 ypos2=2
@@ -39,7 +39,7 @@ unitx=1
 dataset=-1}
 B 2 580 -1000 1170 -540 {flags=graph
 y1=-0
-y2=500
+y2=1300
 ypos1=0
 ypos2=2
 divy=5
@@ -82,7 +82,7 @@ vb b 0 3.3
 .control
 save all
 dc vp 0 3.3 0.01
-write test_ppolyf_u.raw
+write test_ppolyf_u_1k.raw
 .endc
 "}
 C {devices/title.sym} 160 -30 0 0 {name=l5 author="GlobalFoundries PDK Authors"}
@@ -93,9 +93,9 @@ tclcommand="
 xschem raw_read $netlist_dir/[file tail [file rootname [xschem get current_name]]].raw
 "
 }
-C {symbols/ppolyf_u.sym} 130 -410 0 0 {name=R1
+C {symbols/ppolyf_u_1k.sym} 130 -410 0 0 {name=R1
 W=1e-6
 L=1e-6
-model=ppolyf_u
+model=ppolyf_u_1k
 spiceprefix=X
 m=1}

--- a/cells/xschem/tests/test_ppolyf_u_1k.sym
+++ b/cells/xschem/tests/test_ppolyf_u_1k.sym
@@ -1,4 +1,4 @@
-v {xschem version=3.4.5 file_version=1.2
+v {xschem version=3.0.0 file_version=1.2
 
 * Copyright 2022 GlobalFoundries PDK Authors
 *
@@ -15,26 +15,13 @@ v {xschem version=3.4.5 file_version=1.2
 * limitations under the License.
 
 }
-G {}
-K {type=moscap
-format="@spiceprefix@name @pinlist @model c_width=@W c_length=@L m=@m"
-template="name=C1
-W=1e-6
-L=1e-6
-model=cap_nmos_03v3
-spiceprefix=X
-m=1"
+K {type=subcircuit
+format="@name @pinlist @symname"
+template="name=x1"
 }
-V {}
-S {}
-E {}
-L 4 0 10 0 30 {}
-L 4 0 -30 0 -5 {}
-L 4 -15 -5 15 -5 {}
-B 4 -15 5 15 10 {}
-B 5 -2.5 -32.5 2.5 -27.5 {name=G dir=inout propag=1 pinnumber=2}
-B 5 -2.5 27.5 2.5 32.5 {name=B dir=inout propag=0 pinnumber=1}
-T {@m * @W / @L} 20 6.25 0 0 0.2 0.2 {layer=13}
-T {@model} 20 -11.25 0 0 0.2 0.2 {}
-T {@spiceprefix@name} 20 -28.75 0 0 0.2 0.2 {}
-T {PW} -25 12.5 0 0 0.2 0.2 { layer=4}
+T {@symname} -76.5 -6 0 0 0.3 0.3 {}
+T {@name} 135 -22 0 0 0.2 0.2 {}
+L 4 -130 -10 130 -10 {}
+L 4 -130 10 130 10 {}
+L 4 -130 -10 -130 10 {}
+L 4 130 -10 130 10 {}

--- a/cells/xschem/tests/test_ppolyf_u_1k_6p0.sch
+++ b/cells/xschem/tests/test_ppolyf_u_1k_6p0.sch
@@ -21,7 +21,7 @@ V {}
 S {}
 E {}
 B 2 580 -540 1170 -80 {flags=graph
-y1=-0.0067
+y1=-0.0028
 y2=0
 ypos1=0
 ypos2=2
@@ -39,7 +39,7 @@ unitx=1
 dataset=-1}
 B 2 580 -1000 1170 -540 {flags=graph
 y1=-0
-y2=500
+y2=1300
 ypos1=0
 ypos2=2
 divy=5
@@ -73,7 +73,7 @@ value="
 C {devices/lab_pin.sym} 130 -490 0 0 {name=l2 sig_type=std_logic lab=P}
 C {devices/lab_pin.sym} 130 -310 0 0 {name=l3 sig_type=std_logic lab=M}
 C {devices/lab_pin.sym} 80 -410 0 0 {name=l4 sig_type=std_logic lab=B}
-C {devices/code_shown.sym} 300 -450 0 0 {name=NGSPICE only_toplevel=true
+C {devices/code_shown.sym} 270 -450 0 0 {name=NGSPICE only_toplevel=true
 value="
 vp p 0 0
 vm m 0 0
@@ -82,7 +82,7 @@ vb b 0 3.3
 .control
 save all
 dc vp 0 3.3 0.01
-write test_ppolyf_u.raw
+write test_ppolyf_u_1k_6p0.raw
 .endc
 "}
 C {devices/title.sym} 160 -30 0 0 {name=l5 author="GlobalFoundries PDK Authors"}
@@ -93,9 +93,9 @@ tclcommand="
 xschem raw_read $netlist_dir/[file tail [file rootname [xschem get current_name]]].raw
 "
 }
-C {symbols/ppolyf_u.sym} 130 -410 0 0 {name=R1
+C {symbols/ppolyf_u_1k_6p0.sym} 130 -410 0 0 {name=R1
 W=1e-6
 L=1e-6
-model=ppolyf_u
+model=ppolyf_u_1k_6p0
 spiceprefix=X
 m=1}

--- a/cells/xschem/tests/test_ppolyf_u_1k_6p0.sym
+++ b/cells/xschem/tests/test_ppolyf_u_1k_6p0.sym
@@ -1,4 +1,4 @@
-v {xschem version=3.4.5 file_version=1.2
+v {xschem version=3.0.0 file_version=1.2
 
 * Copyright 2022 GlobalFoundries PDK Authors
 *
@@ -15,26 +15,13 @@ v {xschem version=3.4.5 file_version=1.2
 * limitations under the License.
 
 }
-G {}
-K {type=moscap
-format="@spiceprefix@name @pinlist @model c_width=@W c_length=@L m=@m"
-template="name=C1
-W=1e-6
-L=1e-6
-model=cap_nmos_03v3
-spiceprefix=X
-m=1"
+K {type=subcircuit
+format="@name @pinlist @symname"
+template="name=x1"
 }
-V {}
-S {}
-E {}
-L 4 0 10 0 30 {}
-L 4 0 -30 0 -5 {}
-L 4 -15 -5 15 -5 {}
-B 4 -15 5 15 10 {}
-B 5 -2.5 -32.5 2.5 -27.5 {name=G dir=inout propag=1 pinnumber=2}
-B 5 -2.5 27.5 2.5 32.5 {name=B dir=inout propag=0 pinnumber=1}
-T {@m * @W / @L} 20 6.25 0 0 0.2 0.2 {layer=13}
-T {@model} 20 -11.25 0 0 0.2 0.2 {}
-T {@spiceprefix@name} 20 -28.75 0 0 0.2 0.2 {}
-T {PW} -25 12.5 0 0 0.2 0.2 { layer=4}
+T {@symname} -76.5 -6 0 0 0.3 0.3 {}
+T {@name} 135 -22 0 0 0.2 0.2 {}
+L 4 -130 -10 130 -10 {}
+L 4 -130 10 130 10 {}
+L 4 -130 -10 -130 10 {}
+L 4 130 -10 130 10 {}

--- a/cells/xschem/tests/test_ppolyf_u_2k.sch
+++ b/cells/xschem/tests/test_ppolyf_u_2k.sch
@@ -21,7 +21,7 @@ V {}
 S {}
 E {}
 B 2 580 -540 1170 -80 {flags=graph
-y1=-0.0067
+y1=-0.0028
 y2=0
 ypos1=0
 ypos2=2
@@ -39,7 +39,7 @@ unitx=1
 dataset=-1}
 B 2 580 -1000 1170 -540 {flags=graph
 y1=-0
-y2=500
+y2=2600
 ypos1=0
 ypos2=2
 divy=5
@@ -82,7 +82,7 @@ vb b 0 3.3
 .control
 save all
 dc vp 0 3.3 0.01
-write test_ppolyf_u.raw
+write test_ppolyf_u_2k.raw
 .endc
 "}
 C {devices/title.sym} 160 -30 0 0 {name=l5 author="GlobalFoundries PDK Authors"}
@@ -93,9 +93,9 @@ tclcommand="
 xschem raw_read $netlist_dir/[file tail [file rootname [xschem get current_name]]].raw
 "
 }
-C {symbols/ppolyf_u.sym} 130 -410 0 0 {name=R1
+C {symbols/ppolyf_u_2k.sym} 130 -410 0 0 {name=R1
 W=1e-6
 L=1e-6
-model=ppolyf_u
+model=ppolyf_u_2k
 spiceprefix=X
 m=1}

--- a/cells/xschem/tests/test_ppolyf_u_2k.sym
+++ b/cells/xschem/tests/test_ppolyf_u_2k.sym
@@ -1,4 +1,4 @@
-v {xschem version=3.4.5 file_version=1.2
+v {xschem version=3.0.0 file_version=1.2
 
 * Copyright 2022 GlobalFoundries PDK Authors
 *
@@ -15,26 +15,13 @@ v {xschem version=3.4.5 file_version=1.2
 * limitations under the License.
 
 }
-G {}
-K {type=moscap
-format="@spiceprefix@name @pinlist @model c_width=@W c_length=@L m=@m"
-template="name=C1
-W=1e-6
-L=1e-6
-model=cap_nmos_03v3
-spiceprefix=X
-m=1"
+K {type=subcircuit
+format="@name @pinlist @symname"
+template="name=x1"
 }
-V {}
-S {}
-E {}
-L 4 0 10 0 30 {}
-L 4 0 -30 0 -5 {}
-L 4 -15 -5 15 -5 {}
-B 4 -15 5 15 10 {}
-B 5 -2.5 -32.5 2.5 -27.5 {name=G dir=inout propag=1 pinnumber=2}
-B 5 -2.5 27.5 2.5 32.5 {name=B dir=inout propag=0 pinnumber=1}
-T {@m * @W / @L} 20 6.25 0 0 0.2 0.2 {layer=13}
-T {@model} 20 -11.25 0 0 0.2 0.2 {}
-T {@spiceprefix@name} 20 -28.75 0 0 0.2 0.2 {}
-T {PW} -25 12.5 0 0 0.2 0.2 { layer=4}
+T {@symname} -76.5 -6 0 0 0.3 0.3 {}
+T {@name} 135 -22 0 0 0.2 0.2 {}
+L 4 -130 -10 130 -10 {}
+L 4 -130 10 130 10 {}
+L 4 -130 -10 -130 10 {}
+L 4 130 -10 130 10 {}

--- a/cells/xschem/tests/test_ppolyf_u_2k_6p0.sch
+++ b/cells/xschem/tests/test_ppolyf_u_2k_6p0.sch
@@ -21,7 +21,7 @@ V {}
 S {}
 E {}
 B 2 580 -540 1170 -80 {flags=graph
-y1=-0.0067
+y1=-0.0013
 y2=0
 ypos1=0
 ypos2=2
@@ -39,7 +39,7 @@ unitx=1
 dataset=-1}
 B 2 580 -1000 1170 -540 {flags=graph
 y1=-0
-y2=500
+y2=2600
 ypos1=0
 ypos2=2
 divy=5
@@ -73,7 +73,7 @@ value="
 C {devices/lab_pin.sym} 130 -490 0 0 {name=l2 sig_type=std_logic lab=P}
 C {devices/lab_pin.sym} 130 -310 0 0 {name=l3 sig_type=std_logic lab=M}
 C {devices/lab_pin.sym} 80 -410 0 0 {name=l4 sig_type=std_logic lab=B}
-C {devices/code_shown.sym} 300 -450 0 0 {name=NGSPICE only_toplevel=true
+C {devices/code_shown.sym} 270 -450 0 0 {name=NGSPICE only_toplevel=true
 value="
 vp p 0 0
 vm m 0 0
@@ -82,7 +82,7 @@ vb b 0 3.3
 .control
 save all
 dc vp 0 3.3 0.01
-write test_ppolyf_u.raw
+write test_ppolyf_u_2k_6p0.raw
 .endc
 "}
 C {devices/title.sym} 160 -30 0 0 {name=l5 author="GlobalFoundries PDK Authors"}
@@ -93,9 +93,9 @@ tclcommand="
 xschem raw_read $netlist_dir/[file tail [file rootname [xschem get current_name]]].raw
 "
 }
-C {symbols/ppolyf_u.sym} 130 -410 0 0 {name=R1
+C {symbols/ppolyf_u_2k_6p0.sym} 130 -410 0 0 {name=R1
 W=1e-6
 L=1e-6
-model=ppolyf_u
+model=ppolyf_u_2k_6p0
 spiceprefix=X
 m=1}

--- a/cells/xschem/tests/test_ppolyf_u_2k_6p0.sym
+++ b/cells/xschem/tests/test_ppolyf_u_2k_6p0.sym
@@ -1,4 +1,4 @@
-v {xschem version=3.4.5 file_version=1.2
+v {xschem version=3.0.0 file_version=1.2
 
 * Copyright 2022 GlobalFoundries PDK Authors
 *
@@ -15,26 +15,13 @@ v {xschem version=3.4.5 file_version=1.2
 * limitations under the License.
 
 }
-G {}
-K {type=moscap
-format="@spiceprefix@name @pinlist @model c_width=@W c_length=@L m=@m"
-template="name=C1
-W=1e-6
-L=1e-6
-model=cap_nmos_03v3
-spiceprefix=X
-m=1"
+K {type=subcircuit
+format="@name @pinlist @symname"
+template="name=x1"
 }
-V {}
-S {}
-E {}
-L 4 0 10 0 30 {}
-L 4 0 -30 0 -5 {}
-L 4 -15 -5 15 -5 {}
-B 4 -15 5 15 10 {}
-B 5 -2.5 -32.5 2.5 -27.5 {name=G dir=inout propag=1 pinnumber=2}
-B 5 -2.5 27.5 2.5 32.5 {name=B dir=inout propag=0 pinnumber=1}
-T {@m * @W / @L} 20 6.25 0 0 0.2 0.2 {layer=13}
-T {@model} 20 -11.25 0 0 0.2 0.2 {}
-T {@spiceprefix@name} 20 -28.75 0 0 0.2 0.2 {}
-T {PW} -25 12.5 0 0 0.2 0.2 { layer=4}
+T {@symname} -76.5 -6 0 0 0.3 0.3 {}
+T {@name} 135 -22 0 0 0.2 0.2 {}
+L 4 -130 -10 130 -10 {}
+L 4 -130 10 130 10 {}
+L 4 -130 -10 -130 10 {}
+L 4 130 -10 130 10 {}

--- a/cells/xschem/tests/test_ppolyf_u_3k.sch
+++ b/cells/xschem/tests/test_ppolyf_u_3k.sch
@@ -21,7 +21,7 @@ V {}
 S {}
 E {}
 B 2 580 -540 1170 -80 {flags=graph
-y1=-0.0067
+y1=-0.00088
 y2=0
 ypos1=0
 ypos2=2
@@ -39,7 +39,7 @@ unitx=1
 dataset=-1}
 B 2 580 -1000 1170 -540 {flags=graph
 y1=-0
-y2=500
+y2=3800
 ypos1=0
 ypos2=2
 divy=5
@@ -82,7 +82,7 @@ vb b 0 3.3
 .control
 save all
 dc vp 0 3.3 0.01
-write test_ppolyf_u.raw
+write test_ppolyf_u_3k.raw
 .endc
 "}
 C {devices/title.sym} 160 -30 0 0 {name=l5 author="GlobalFoundries PDK Authors"}
@@ -93,9 +93,9 @@ tclcommand="
 xschem raw_read $netlist_dir/[file tail [file rootname [xschem get current_name]]].raw
 "
 }
-C {symbols/ppolyf_u.sym} 130 -410 0 0 {name=R1
+C {symbols/ppolyf_u_3k.sym} 130 -410 0 0 {name=R1
 W=1e-6
 L=1e-6
-model=ppolyf_u
+model=ppolyf_u_3k
 spiceprefix=X
 m=1}

--- a/cells/xschem/tests/test_ppolyf_u_3k.sym
+++ b/cells/xschem/tests/test_ppolyf_u_3k.sym
@@ -1,4 +1,4 @@
-v {xschem version=3.4.5 file_version=1.2
+v {xschem version=3.0.0 file_version=1.2
 
 * Copyright 2022 GlobalFoundries PDK Authors
 *
@@ -15,26 +15,13 @@ v {xschem version=3.4.5 file_version=1.2
 * limitations under the License.
 
 }
-G {}
-K {type=moscap
-format="@spiceprefix@name @pinlist @model c_width=@W c_length=@L m=@m"
-template="name=C1
-W=1e-6
-L=1e-6
-model=cap_nmos_03v3
-spiceprefix=X
-m=1"
+K {type=subcircuit
+format="@name @pinlist @symname"
+template="name=x1"
 }
-V {}
-S {}
-E {}
-L 4 0 10 0 30 {}
-L 4 0 -30 0 -5 {}
-L 4 -15 -5 15 -5 {}
-B 4 -15 5 15 10 {}
-B 5 -2.5 -32.5 2.5 -27.5 {name=G dir=inout propag=1 pinnumber=2}
-B 5 -2.5 27.5 2.5 32.5 {name=B dir=inout propag=0 pinnumber=1}
-T {@m * @W / @L} 20 6.25 0 0 0.2 0.2 {layer=13}
-T {@model} 20 -11.25 0 0 0.2 0.2 {}
-T {@spiceprefix@name} 20 -28.75 0 0 0.2 0.2 {}
-T {PW} -25 12.5 0 0 0.2 0.2 { layer=4}
+T {@symname} -76.5 -6 0 0 0.3 0.3 {}
+T {@name} 135 -22 0 0 0.2 0.2 {}
+L 4 -130 -10 130 -10 {}
+L 4 -130 10 130 10 {}
+L 4 -130 -10 -130 10 {}
+L 4 130 -10 130 10 {}

--- a/cells/xschem/tests/test_rm2.sch
+++ b/cells/xschem/tests/test_rm2.sch
@@ -21,7 +21,7 @@ V {}
 S {}
 E {}
 B 2 580 -540 1170 -80 {flags=graph
-y1=-0.0067
+y1=-0.37
 y2=0
 ypos1=0
 ypos2=2
@@ -39,7 +39,7 @@ unitx=1
 dataset=-1}
 B 2 580 -1000 1170 -540 {flags=graph
 y1=-0
-y2=500
+y2=9.1
 ypos1=0
 ypos2=2
 divy=5
@@ -77,25 +77,25 @@ C {devices/code_shown.sym} 300 -450 0 0 {name=NGSPICE only_toplevel=true
 value="
 vp p 0 0
 vm m 0 0
-vb b 0 3.3
+vb b 0 0
 
 .control
 save all
 dc vp 0 3.3 0.01
-write test_ppolyf_u.raw
+write test_rm2.raw
 .endc
 "}
 C {devices/title.sym} 160 -30 0 0 {name=l5 author="GlobalFoundries PDK Authors"}
-C {devices/launcher.sym} 65 -645 0 0 {name=h1
+C {devices/launcher.sym} 65 -625 0 0 {name=h1
 descr="Click left mouse button here with control key
 pressed to load/unload waveforms in graph."
 tclcommand="
 xschem raw_read $netlist_dir/[file tail [file rootname [xschem get current_name]]].raw
 "
 }
-C {symbols/ppolyf_u.sym} 130 -410 0 0 {name=R1
-W=1e-6
-L=1e-6
-model=ppolyf_u
+C {symbols/rm2.sym} 130 -410 0 0 {name=R1
+W=0.6e-6
+L=60e-6
+model=rm2
 spiceprefix=X
 m=1}

--- a/cells/xschem/tests/test_rm2.sym
+++ b/cells/xschem/tests/test_rm2.sym
@@ -1,4 +1,4 @@
-v {xschem version=3.4.5 file_version=1.2
+v {xschem version=3.0.0 file_version=1.2
 
 * Copyright 2022 GlobalFoundries PDK Authors
 *
@@ -15,26 +15,13 @@ v {xschem version=3.4.5 file_version=1.2
 * limitations under the License.
 
 }
-G {}
-K {type=moscap
-format="@spiceprefix@name @pinlist @model c_width=@W c_length=@L m=@m"
-template="name=C1
-W=1e-6
-L=1e-6
-model=cap_nmos_03v3
-spiceprefix=X
-m=1"
+K {type=subcircuit
+format="@name @pinlist @symname"
+template="name=x1"
 }
-V {}
-S {}
-E {}
-L 4 0 10 0 30 {}
-L 4 0 -30 0 -5 {}
-L 4 -15 -5 15 -5 {}
-B 4 -15 5 15 10 {}
-B 5 -2.5 -32.5 2.5 -27.5 {name=G dir=inout propag=1 pinnumber=2}
-B 5 -2.5 27.5 2.5 32.5 {name=B dir=inout propag=0 pinnumber=1}
-T {@m * @W / @L} 20 6.25 0 0 0.2 0.2 {layer=13}
-T {@model} 20 -11.25 0 0 0.2 0.2 {}
-T {@spiceprefix@name} 20 -28.75 0 0 0.2 0.2 {}
-T {PW} -25 12.5 0 0 0.2 0.2 { layer=4}
+T {@symname} -76.5 -6 0 0 0.3 0.3 {}
+T {@name} 135 -22 0 0 0.2 0.2 {}
+L 4 -130 -10 130 -10 {}
+L 4 -130 10 130 10 {}
+L 4 -130 -10 -130 10 {}
+L 4 130 -10 130 10 {}

--- a/cells/xschem/tests/test_rm3.sch
+++ b/cells/xschem/tests/test_rm3.sch
@@ -21,7 +21,7 @@ V {}
 S {}
 E {}
 B 2 580 -540 1170 -80 {flags=graph
-y1=-0.0067
+y1=-0.37
 y2=0
 ypos1=0
 ypos2=2
@@ -39,7 +39,7 @@ unitx=1
 dataset=-1}
 B 2 580 -1000 1170 -540 {flags=graph
 y1=-0
-y2=500
+y2=9.1
 ypos1=0
 ypos2=2
 divy=5
@@ -77,25 +77,25 @@ C {devices/code_shown.sym} 300 -450 0 0 {name=NGSPICE only_toplevel=true
 value="
 vp p 0 0
 vm m 0 0
-vb b 0 3.3
+vb b 0 0
 
 .control
 save all
 dc vp 0 3.3 0.01
-write test_ppolyf_u.raw
+write test_rm3.raw
 .endc
 "}
 C {devices/title.sym} 160 -30 0 0 {name=l5 author="GlobalFoundries PDK Authors"}
-C {devices/launcher.sym} 65 -645 0 0 {name=h1
+C {devices/launcher.sym} 65 -625 0 0 {name=h1
 descr="Click left mouse button here with control key
 pressed to load/unload waveforms in graph."
 tclcommand="
 xschem raw_read $netlist_dir/[file tail [file rootname [xschem get current_name]]].raw
 "
 }
-C {symbols/ppolyf_u.sym} 130 -410 0 0 {name=R1
-W=1e-6
-L=1e-6
-model=ppolyf_u
+C {symbols/rm3.sym} 130 -410 0 0 {name=R1
+W=0.6e-6
+L=60e-6
+model=rm3
 spiceprefix=X
 m=1}

--- a/cells/xschem/tests/test_rm3.sym
+++ b/cells/xschem/tests/test_rm3.sym
@@ -1,4 +1,4 @@
-v {xschem version=3.4.5 file_version=1.2
+v {xschem version=3.0.0 file_version=1.2
 
 * Copyright 2022 GlobalFoundries PDK Authors
 *
@@ -15,26 +15,13 @@ v {xschem version=3.4.5 file_version=1.2
 * limitations under the License.
 
 }
-G {}
-K {type=moscap
-format="@spiceprefix@name @pinlist @model c_width=@W c_length=@L m=@m"
-template="name=C1
-W=1e-6
-L=1e-6
-model=cap_nmos_03v3
-spiceprefix=X
-m=1"
+K {type=subcircuit
+format="@name @pinlist @symname"
+template="name=x1"
 }
-V {}
-S {}
-E {}
-L 4 0 10 0 30 {}
-L 4 0 -30 0 -5 {}
-L 4 -15 -5 15 -5 {}
-B 4 -15 5 15 10 {}
-B 5 -2.5 -32.5 2.5 -27.5 {name=G dir=inout propag=1 pinnumber=2}
-B 5 -2.5 27.5 2.5 32.5 {name=B dir=inout propag=0 pinnumber=1}
-T {@m * @W / @L} 20 6.25 0 0 0.2 0.2 {layer=13}
-T {@model} 20 -11.25 0 0 0.2 0.2 {}
-T {@spiceprefix@name} 20 -28.75 0 0 0.2 0.2 {}
-T {PW} -25 12.5 0 0 0.2 0.2 { layer=4}
+T {@symname} -76.5 -6 0 0 0.3 0.3 {}
+T {@name} 135 -22 0 0 0.2 0.2 {}
+L 4 -130 -10 130 -10 {}
+L 4 -130 10 130 10 {}
+L 4 -130 -10 -130 10 {}
+L 4 130 -10 130 10 {}

--- a/cells/xschem/tests/test_sc_diode.sch
+++ b/cells/xschem/tests/test_sc_diode.sch
@@ -20,33 +20,16 @@ K {}
 V {}
 S {}
 E {}
-B 2 580 -540 1170 -80 {flags=graph
-y1=-0.0067
-y2=0
+B 2 750 -540 1340 -80 {flags=graph
+y1=-0.00013
+y2=2.6e-10
 ypos1=0
 ypos2=2
 divy=5
 subdivy=1
-unity=m
-x1=0
-x2=3.3
-divx=5
-subdivx=1
-node=i(vp)
-color=4
-
-unitx=1
-dataset=-1}
-B 2 580 -1000 1170 -540 {flags=graph
-y1=-0
-y2=500
-ypos1=0
-ypos2=2
-divy=5
-subdivy=1
-unity=1
-x1=0
-x2=3.3
+unity=u
+x1=-0.4
+x2=0.8
 divx=5
 subdivx=1
 
@@ -54,48 +37,46 @@ subdivx=1
 
 unitx=1
 dataset=-1
+
 color=4
-node="\\"resistance; p i(vp) / -1 *\\""}
-N 130 -490 130 -440 {
+node=i(vp)}
+N 230 -470 230 -420 {
 lab=P}
-N 80 -410 110 -410 {
-lab=B}
-N 130 -380 130 -310 {
-lab=M}
-C {devices/code_shown.sym} 20 -160 0 0 {name=MODELS only_toplevel=true
+N 230 -360 230 -290 {
+lab=GND}
+N 230 -490 230 -470 {
+lab=P}
+C {devices/code_shown.sym} 30 -200 0 0 {name=MODELS only_toplevel=true
 format="tcleval( @value )"
 value="
 .include $::180MCU_MODELS/design.ngspice
 .lib $::180MCU_MODELS/sm141064.ngspice typical
 .lib $::180MCU_MODELS/sm141064.ngspice res_typical
+.lib $::180MCU_MODELS/sm141064.ngspice moscap_typical
+.lib $::180MCU_MODELS/sm141064.ngspice diode_typical
 * .lib $::180MCU_MODELS/sm141064.ngspice res_statistical
 "}
-C {devices/lab_pin.sym} 130 -490 0 0 {name=l2 sig_type=std_logic lab=P}
-C {devices/lab_pin.sym} 130 -310 0 0 {name=l3 sig_type=std_logic lab=M}
-C {devices/lab_pin.sym} 80 -410 0 0 {name=l4 sig_type=std_logic lab=B}
-C {devices/code_shown.sym} 300 -450 0 0 {name=NGSPICE only_toplevel=true
+C {devices/code_shown.sym} 390 -450 0 0 {name=NGSPICE only_toplevel=true
 value="
 vp p 0 0
-vm m 0 0
-vb b 0 3.3
-
 .control
 save all
-dc vp 0 3.3 0.01
-write test_ppolyf_u.raw
+dc vp -0.4 0.8 0.001
+write test_sc_diode.raw
 .endc
 "}
 C {devices/title.sym} 160 -30 0 0 {name=l5 author="GlobalFoundries PDK Authors"}
-C {devices/launcher.sym} 65 -645 0 0 {name=h1
+C {devices/launcher.sym} 185 -635 0 0 {name=h1
 descr="Click left mouse button here with control key
 pressed to load/unload waveforms in graph."
 tclcommand="
 xschem raw_read $netlist_dir/[file tail [file rootname [xschem get current_name]]].raw
 "
 }
-C {symbols/ppolyf_u.sym} 130 -410 0 0 {name=R1
-W=1e-6
-L=1e-6
-model=ppolyf_u
-spiceprefix=X
+C {devices/gnd.sym} 230 -290 0 0 {name=l2 lab=GND}
+C {devices/lab_pin.sym} 230 -490 0 1 {name=l3 sig_type=std_logic lab=P}
+C {symbols/sc_diode.sym} 230 -390 0 0 {name=D1
+model=sc_diode
+r_w=1u
+r_l=1u
 m=1}

--- a/cells/xschem/tests/test_sc_diode.sym
+++ b/cells/xschem/tests/test_sc_diode.sym
@@ -1,4 +1,4 @@
-v {xschem version=3.4.5 file_version=1.2
+v {xschem version=3.0.0 file_version=1.2
 
 * Copyright 2022 GlobalFoundries PDK Authors
 *
@@ -15,26 +15,13 @@ v {xschem version=3.4.5 file_version=1.2
 * limitations under the License.
 
 }
-G {}
-K {type=moscap
-format="@spiceprefix@name @pinlist @model c_width=@W c_length=@L m=@m"
-template="name=C1
-W=1e-6
-L=1e-6
-model=cap_nmos_03v3
-spiceprefix=X
-m=1"
+K {type=subcircuit
+format="@name @pinlist @symname"
+template="name=x1"
 }
-V {}
-S {}
-E {}
-L 4 0 10 0 30 {}
-L 4 0 -30 0 -5 {}
-L 4 -15 -5 15 -5 {}
-B 4 -15 5 15 10 {}
-B 5 -2.5 -32.5 2.5 -27.5 {name=G dir=inout propag=1 pinnumber=2}
-B 5 -2.5 27.5 2.5 32.5 {name=B dir=inout propag=0 pinnumber=1}
-T {@m * @W / @L} 20 6.25 0 0 0.2 0.2 {layer=13}
-T {@model} 20 -11.25 0 0 0.2 0.2 {}
-T {@spiceprefix@name} 20 -28.75 0 0 0.2 0.2 {}
-T {PW} -25 12.5 0 0 0.2 0.2 { layer=4}
+T {@symname} -76.5 -6 0 0 0.3 0.3 {}
+T {@name} 135 -22 0 0 0.2 0.2 {}
+L 4 -130 -10 130 -10 {}
+L 4 -130 10 130 10 {}
+L 4 -130 -10 -130 10 {}
+L 4 130 -10 130 10 {}


### PR DESCRIPTION
Following devices have been added:
```
cells/xschem/symbols/cap_mim_1f0fF.sym
cells/xschem/symbols/cap_mim_1f5fF.sym
cells/xschem/symbols/cap_mim_2f0fF.sym
cells/xschem/symbols/cap_mim_analog.sym
cells/xschem/symbols/cap_nmos_03v3_b.sym
cells/xschem/symbols/cap_nmos_06v0_b.sym
cells/xschem/symbols/cap_pmos_03v3_b.sym
cells/xschem/symbols/cap_pmos_06v0_b.sym
cells/xschem/symbols/diode_dw2ps.sym
cells/xschem/symbols/diode_nd2ps_06v0.sym
cells/xschem/symbols/diode_nw2ps_03v3.sym
cells/xschem/symbols/diode_nw2ps_06v0.sym
cells/xschem/symbols/diode_pd2nw_03v3.sym
cells/xschem/symbols/diode_pd2nw_06v0.sym
cells/xschem/symbols/nfet_06v0_dss.sym
cells/xschem/symbols/nfet_10v0_asym.sym
cells/xschem/symbols/npn_00p54x02p00.sym
cells/xschem/symbols/npn_00p54x04p00.sym
cells/xschem/symbols/npn_00p54x08p00.sym
cells/xschem/symbols/npn_00p54x16p00.sym
cells/xschem/symbols/npn_05p00x05p00.sym
cells/xschem/symbols/npolyf_s.sym
cells/xschem/symbols/pfet_06v0_dss.sym
cells/xschem/symbols/pfet_10v0_asym.sym
cells/xschem/symbols/pnp_05p00x00p42.sym
cells/xschem/symbols/pnp_05p00x05p00.sym
cells/xschem/symbols/pnp_10p00x00p42.sym
cells/xschem/symbols/ppolyf_s.sym
cells/xschem/symbols/ppolyf_u_1k.sym
cells/xschem/symbols/ppolyf_u_1k_6p0.sym
cells/xschem/symbols/ppolyf_u_2k.sym
cells/xschem/symbols/ppolyf_u_2k_6p0.sym
cells/xschem/symbols/ppolyf_u_3k.sym
cells/xschem/symbols/rm2.sym
cells/xschem/symbols/rm3.sym
cells/xschem/symbols/sc_diode.sym
```
For each new `device` a `test_device.sch` has been created in `cells/xschem/tests/`
A basic simulation has been run for each new device to verify correct xschem - spice model binding.

So far `rm4` and `rm5` metal resistors are not in the list since I didn't find the spice model.
As soon as I get the models to use I will add these two remaining symbols in another PR.

the `cap_mim_analog` addresses these device models:
```
 cap_mim_1f5_m2m3_noshield
 cap_mim_1f0_m2m3_noshield
 cap_mim_2f0_m2m3_noshield
 cap_mim_1f5_m3m4_noshield
 cap_mim_1f0_m3m4_noshield
 cap_mim_2f0_m3m4_noshield
 cap_mim_1f5_m4m5_noshield
 cap_mim_1f0_m4m5_noshield
 cap_mim_2f0_m4m5_noshield
 cap_mim_1f5_m5m6_noshield
 cap_mim_1f0_m5m6_noshield
 cap_mim_2f0_m5m6_noshield
```