### PR TITLE
Update path to standard symbols

### DIFF
--- a/cells/xschem/xschemrc
+++ b/cells/xschem/xschemrc
@@ -28,7 +28,8 @@
 #### Flush any previous definition
 set XSCHEM_LIBRARY_PATH {}
 #### include devices/*.sym
-append XSCHEM_LIBRARY_PATH ${XSCHEM_SHAREDIR}/xschem_library
+append XSCHEM_LIBRARY_PATH :${XSCHEM_SHAREDIR}/xschem_library/devices
+append XSCHEM_LIBRARY_PATH :${XSCHEM_SHAREDIR}/xschem_library
 #### include skywater libraries. Here i use [pwd]. This works if i start xschem from here.
 append XSCHEM_LIBRARY_PATH :$env(PWD)
 # append XSCHEM_LIBRARY_PATH :/mnt/sda7/home/schippes/pdks/sky130A/libs.tech/xschem


### PR DESCRIPTION
This change is analogous to the one in [sky130 xschemrc](https://github.com/StefanSchippers/xschem_sky130/commit/0597d6cd26ad460d3f4d689f9e6a11f33dc262ff).

The reason for the change is that standard symbols that are placed when using the gf180mcu PDK have a devices/ prefix in their symbol reference, because the full path to the standard devices is not specified. This means that schematics created with the default xschem setup and using this PDK are not compatible. This incompatibility is not necessary and prevents, for example, the sharing of simple testbenches without correcting the paths.

This change appends the path `:${XSCHEM_SHAREDIR}/xschem_library/devices` before `append XSCHEM_LIBRARY_PATH :${XSCHEM_SHAREDIR}/xschem_library`, thus newly placed symbols will not have devices/ in their symbol reference and are compatible with the default xschem setup.